### PR TITLE
Misspelled word on line no. 290

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Role variables
 This role has many variables values that can be changed to best suit
 your needs.
 
-Below are listed all the variables you can customize (you ma also want to take a look at
+Below are listed all the variables you can customize (you may also want to take a look at
 [the default values of these variables](https://github.com/openwisp/ansible-openwisp2/blob/master/defaults/main.yml)).
 
 ```yaml


### PR DESCRIPTION
The word 'may' was spelled as 'ma'.