### PR TITLE
Improved installation guide a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The `-k` argument will need the `sshpass` program.
 
 You can remove `-k`, `--become` and `-K` if your public SSH key is installed on the server.
 
-**Tip**: if you have a error like `Authentication or permission failure` then try to use *root* user `ansible-playbook -i hosts playbook.yml -u root -k`
+**Tip**: if you have an error like `Authentication or permission failure` then try to use *root* user `ansible-playbook -i hosts playbook.yml -u root -k`
 
 When the playbook is done running, if you got no errors you can login at:
 

--- a/README.md
+++ b/README.md
@@ -123,13 +123,15 @@ Now is time to **deploy openwisp2 to the production server**.
 
 Run the playbook **from your local machine** with:
 
-    ansible-playbook -i hosts playbook.yml -u <user> -k --ask-sudo-pass
+    ansible-playbook -i hosts playbook.yml -u <user> -k --become -K
 
 Substitute `<user>` with your user.
 
-The `--ask-sudo-pass` argument will need the `sshpass` program.
+The `-k` argument will need the `sshpass` program.
 
-You can remove `-k` and `--ask-sudo-pass` if your public SSH key is installed on the server.
+You can remove `-k`, `--become` and `-K` if your public SSH key is installed on the server.
+
+**Tip**: if you have a error like `Authentication or permission failure` then try to use *root* user `ansible-playbook -i hosts playbook.yml -u root -k`
 
 When the playbook is done running, if you got no errors you can login at:
 


### PR DESCRIPTION
1) The `--ask-sudo-pass` argument will not need the sshpass program. Any ssh connection with password will need sshpass program
Proof: ansible-playbook -i hosts playbook.yml -u artem -k
...
fatal: [192.168.1.15]: FAILED! => {"msg": "to use the 'ssh' connection type with passwords, you must install the sshpass program"}
(there no `--ask-sudo-pass` argument)
2) The `--ask-sudo-pass` is "deprecated, use become", so replace it to become :)
3) I had problem "Authentication or permission failure" so using root access (login) directly fixed it