### PR TITLE
[python_update] Adds task to update to python3.6

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 openwisp2_python: python3
+openwisp2_python_update: false
 openwisp2_network_topology: false
 openwisp2_controller_pip: false
 openwisp2_users_pip: false

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -89,3 +89,8 @@
   apt:
     name: ntp
     state: latest
+
+- name: Install checkinstall
+  apt:
+      name: checkinstall
+      state: latest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,3 +37,5 @@
 
 - import_tasks: complete.yml
   tags: [openwisp2]
+
+- import_tasks: python_upgrade.yml

--- a/tasks/python_update.yml
+++ b/tasks/python_update.yml
@@ -1,0 +1,9 @@
+- name: Install python3.6 if python update is true
+  get_url: 
+    url: "{{ python3.6_package_url }}"
+    dest: "/home/{{ ansible_env.USER }}/Downloads/{{ python_package_name }}.deb"
+
+- name: Installing the deb package
+  apt: deb="/home/{{ ansible_env.USER }}/Downloads/{{ python_package_name }}.deb"
+  sudo: true
+  when: openwisp2_python_update = true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,1 +1,3 @@
 virtualenv_path: "{{ openwisp2_path }}/env"
+python3.6_package_url: "https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tgz"
+python3.6_package_name: "python3.6.3"


### PR DESCRIPTION
Adds task python_update to install python3.6.3 from its deb packages. Set variable `openwisp2_python_update` to `true` to run the task.

Fixes #61