### PR TITLE
[django_cache] Adds cache templating settings #78

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,3 +70,5 @@ openwisp2_nginx_ssl_config:
         - "application/xml"
         - "application/x-font-ttf"
         - "font/opentype"
+
+openwisp2_redis_location: redis://127.0.0.1:6379/1

--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -106,11 +106,10 @@ TEMPLATES = [
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'OPTIONS': {
-            'loaders': [
+            'loaders': ('django.template.loaders.cached.Loader', [
                 'django.template.loaders.filesystem.Loader',
                 'django.template.loaders.app_directories.Loader',
-                'openwisp_utils.loaders.DependencyLoader'
-            ],
+            ]),
             'context_processors': [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
@@ -120,6 +119,21 @@ TEMPLATES = [
         },
     },
 ]
+
+# FOR DJANGO REDIS
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "{{ openwisp2_redis_location }}",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        }
+    }
+}
+
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+SESSION_CACHE_ALIAS = "default"
 
 FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'
 


### PR DESCRIPTION
Made changes to settings.py in templates/openwisp2 from the references mentioned to enable djnago templating using django redis

Fixes Issue #78