### PR TITLE
[pkg] Install libsqlite3-mod-spatialite only when needed

### DIFF
--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -29,16 +29,18 @@
     - libspatialite-dev
 
 - name: Install mod-spatialite (may fail on older linux distros)
+  when: openwisp2_database.engine == "django.contrib.gis.db.backends.spatialite"
   ignore_errors: yes
   apt: name=libsqlite3-mod-spatialite state=latest
-  register: mod_spatialie_result
+  register: mod_spatialite_result
 
 - name: Set openwisp2_spatialite_path
   set_fact:
     openwisp2_spatialite_path: false
   when: >
-    openwisp2_spatialite_path == 'mod_spatialite'
-    and mod_spatialie_result is failed
+    openwisp2_database.engine != "django.contrib.gis.db.backends.spatialite"
+    or (openwisp2_spatialite_path == 'mod_spatialite'
+        and mod_spatialite_result is failed)
 
 # fixes issue described in https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user
 - name: Install acl if acting as non-root user

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -45,7 +45,6 @@
 - name: Set openwisp2_spatialite_path
   set_fact:
     openwisp2_spatialite_path: false
-  when: openwisp2_spatialite_path == 'mod_spatialite'
 
 - name: ensure supervisor is started
   service: name=supervisord state=started enabled=yes


### PR DESCRIPTION
This package shouldn't be installed when using another DB
eg: PostgreSQL with the Postgis extension.