### PR TITLE
[variables][Fixes #77] Spatialite Path Changes According to OS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,13 @@ Ubuntu1604:
 
   <<: *testing_script
 
+Ubuntu1804:
+  variables:
+    distro: 'ubuntu:18.04'
+    playbook: test.yml
+
+  <<: *testing_script
+
 Centos7:
   variables:
     distro: centos:7
@@ -56,9 +63,23 @@ Debian9:
 
   <<: *testing_script
 
-Ubuntu1604_NetworkTopology:
+Debian10:
   variables:
-    distro: 'ubuntu:16.04'
+    distro: debian:10
+    playbook: test.yml
+
+  <<: *testing_script
+
+Fedora27:
+  variables:
+    distro: fedora:27
+    playbook: test.yml
+
+  <<: *testing_script
+
+Ubuntu1804_NetworkTopology:
+  variables:
+    distro: 'ubuntu:18.04'
     playbook: test_networktopology.yml
 
   <<: *testing_script

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,18 @@ env:
     playbook: test.yml
   - distro: 'ubuntu:16.04'
     playbook: test.yml
+  - distro: 'ubuntu:18.04'
+    playbook: test.yml
   - distro: debian:8
     playbook: test.yml
   - distro: debian:9
     playbook: test.yml
+  - distro: debian:10
+    playbook: test.yml
+  - distro: fedora:27
+    playbook: test.yml
 
-  - distro: 'ubuntu:16.04'
+  - distro: 'ubuntu:18.04'
     playbook: test_networktopology.yml
 
 script:

--- a/README.md
+++ b/README.md
@@ -436,7 +436,9 @@ Below are listed all the variables you can customize (you may also want to take 
         port: ""
         options: {}
     # SPATIALITE_LIBRARY_PATH django setting
-    openwisp2_spatialite_path: "mod_spatialite"
+    # The role will attempt determining the right mod-spatialite path automatically
+    # But you can use this variable to customize the path or fix future arising issues
+    openwisp2_spatialite_path: null
     # customize other django settings:
     openwisp2_language_code: en-gb
     openwisp2_time_zone: UTC

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ openwisp2_database:
     host: ""
     port: ""
     options: {}
-openwisp2_spatialite_path: "mod_spatialite"
+openwisp2_spatialite_path: null
 openwisp2_language_code: "en-gb"
 openwisp2_time_zone: "UTC"
 openwisp2_context: {}

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -32,15 +32,6 @@
   when: openwisp2_database.engine == "django.contrib.gis.db.backends.spatialite"
   ignore_errors: yes
   apt: name=libsqlite3-mod-spatialite state=latest
-  register: mod_spatialite_result
-
-- name: Set openwisp2_spatialite_path
-  set_fact:
-    openwisp2_spatialite_path: false
-  when: >
-    openwisp2_database.engine != "django.contrib.gis.db.backends.spatialite"
-    or (openwisp2_spatialite_path == 'mod_spatialite'
-        and mod_spatialite_result is failed)
 
 # fixes issue described in https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user
 - name: Install acl if acting as non-root user

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,12 @@
 - import_tasks: variables.yml
   tags: [openwisp2, apt, yum, pip, django, supervisor, nginx, variables]
 
+- import_tasks: variables-spatialite.yml
+  tags: [openwisp2, apt, yum, pip, django, supervisor, nginx, variables]
+  when: >
+    openwisp2_database.engine == "django.contrib.gis.db.backends.spatialite"
+    and openwisp2_spatialite_path is none
+
 - import_tasks: apt.yml
   tags: [openwisp2, apt]
   when: ansible_os_family == 'Debian'

--- a/tasks/variables-spatialite.yml
+++ b/tasks/variables-spatialite.yml
@@ -1,0 +1,22 @@
+- name: Set spatialite_path for Fedora
+  set_fact:
+    openwisp2_spatialite_path: "mod_spatialite"
+  when: ansible_distribution == 'Fedora'
+
+- name: Set spatialite_path (Ubuntu >= 18.04 or Debian >= 10)
+  set_fact:
+    openwisp2_spatialite_path: "mod_spatialite.so"
+  when: >
+    (ansible_distribution == 'Ubuntu' 
+    and ansible_distribution_version is version_compare('18.04', 'ge')) 
+    or (ansible_distribution == 'Debian' and 
+    ansible_distribution_version is version_compare('10', 'ge'))
+
+- name: Set spatialite_path (Ubuntu >= 16.04 or Debian >= 9)
+  set_fact:
+    openwisp2_spatialite_path: "mod_spatialite"
+  when: >
+    (ansible_distribution == 'Ubuntu'
+    and ansible_distribution_version is version_compare('16.04', 'ge'))
+    or (ansible_distribution == 'Debian'
+    and ansible_distribution_version is version_compare('9', 'ge'))

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -41,11 +41,6 @@
     - geos-devel
     - libspatialite-devel
 
-# mod-spatialite doesn't seem available on RedHat yet
-- name: Set openwisp2_spatialite_path
-  set_fact:
-    openwisp2_spatialite_path: false
-
 - name: ensure supervisor is started
   service: name=supervisord state=started enabled=yes
 


### PR DESCRIPTION
- `openwisp2_spatialite_path` value changes according to `ansible_distribution` & `ansible_distribution_version`
- added `.travis.yml` & `.gitlab-ci.yml` jobs for `debian 10` and `ubuntu 18.04`

Fixes #77