### PR TITLE
[pip] Install django-redis without triggering dependencies upgrade

### DIFF
--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -46,8 +46,15 @@
     # add asgi_redis for websockets
     - asgi_redis
     - service_identity
-    # django-redis for caching
-    - django-redis
+  notify: reload supervisor
+
+- name: Install django-redis
+  pip:
+    name: "django-redis>=4.9.0"
+    state: present
+    virtualenv: "{{ virtualenv_path }}"
+    virtualenv_python: "{{ openwisp2_python }}"
+    virtualenv_site_packages: yes
   notify: reload supervisor
 
 - name: Install openwisp2 network topology and its dependencies


### PR DESCRIPTION
If the upgrade of the dependencies is triggered, not yet compatible
version of django may be installed breaking the openwisp2 instance.

#103 and #105 should be addressed before merging this PR.