### PR TITLE
[apt + pip] Fix Ansible deprecation warnings #86

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Tested on **debian**, **ubuntu**, **fedora**, **redhat** and **centos**.
 
 **NOTE**: it is highly suggested to use this procedure on clean virtual machines or linux containers.
 
-**Minimum ansible version supported**: 2.4.
+**Minimum ansible version supported**: 2.5.
 
 Help OpenWISP
 =============
@@ -62,7 +62,7 @@ please read [Install OpenWISP2 for testing in a VirtualBox VM](#install-openwisp
 Install ansible
 ---------------
 
-Install ansible (version 2.4 or higher) **on your local machine** (not the production server!) if
+Install ansible (version 2.5 or higher) **on your local machine** (not the production server!) if
 you haven't done already.
 
 To **install ansible** we suggest you follow the official [ansible installation guide](http://docs.ansible.com/ansible/latest/intro_installation.html).

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
   company: Cineca
   description: Official role to install and upgrade openwisp2 controller
   license: BSD
-  min_ansible_version: 2.4
+  min_ansible_version: 2.5
   issue_tracker_url: https://github.com/openwisp/ansible-openwisp2/issues
   platforms:
   - name: Debian

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -3,21 +3,22 @@
   changed_when: false
 
 - name: Install system packages
-  apt: name={{ item }} state=latest
-  notify: 
+  apt:
+    name:
+      - sudo
+      - software-properties-common
+      - build-essential
+      - supervisor
+      - nginx
+      - openssl
+      - libssl-dev
+      - libffi-dev
+      - python-dev
+      - redis-server
+    state: latest
+  notify:
     - reload systemd
     - start redis-server
-  with_items:
-    - sudo
-    - software-properties-common
-    - build-essential
-    - supervisor
-    - nginx
-    - openssl
-    - libssl-dev
-    - libffi-dev
-    - python-dev
-    - redis-server
 
 # On the newer versions of redis, by default redis
 # binds to localhost on ipv6 address which wouldn't
@@ -33,14 +34,15 @@
 
 - name: Install spatialite
   when: openwisp2_database.engine == "django.contrib.gis.db.backends.spatialite"
-  apt: name={{ item }} state=latest
+  apt:
+    name:
+      - sqlite3
+      - gdal-bin
+      - libproj-dev
+      - libgeos-dev
+      - libspatialite-dev
+    state: latest
   notify: reload systemd
-  with_items:
-    - sqlite3
-    - gdal-bin
-    - libproj-dev
-    - libgeos-dev
-    - libspatialite-dev
 
 - name: Install mod-spatialite (may fail on older linux distros)
   when: openwisp2_database.engine == "django.contrib.gis.db.backends.spatialite"
@@ -57,40 +59,45 @@
 
 - name: Install python2 packages
   when: openwisp2_python in ["python2.7", "python2"]
-  apt: name={{ item }} state=latest
-  with_items:
-    - python-pip
-    - python-dev
-    - python-virtualenv
+  apt:
+    name:
+      - python-pip
+      - python-dev
+      - python-virtualenv
+    state: latest
 
 - name: Install python3 packages
   when: openwisp2_python == "python3"
-  apt: name={{ item }} state=latest
-  with_items:
-    - python3
-    - python3-pip
-    - python3-dev
-    - python-virtualenv
+  apt:
+    name:
+      - python3
+      - python3-pip
+      - python3-dev
+      - python-virtualenv
+    state: latest
 
 - name: Install python3-pyparsing
   when: ansible_distribution == "Debian" and ansible_distribution_version == "9.0"
-  apt: name={{ item }} state=latest
-  with_items:
-    - python3-pyparsing
+  apt:
+    name:
+      - python3-pyparsing
+    state: latest
 
 - name: Install python wheel (optional, allowed to fail)
   ignore_errors: yes
-  apt: name={{ item }} state=latest
-  with_items:
-    - python-wheel
-    - python3-wheel
+  apt:
+    name:
+      - python-wheel
+      - python3-wheel
+    state: latest
 
 - name: Install python3-virtualenv
   ignore_errors: yes
   when: ansible_distribution != 'Ubuntu'
-  apt: name={{ item }} state=latest
-  with_items:
-    - python3-virtualenv
+  apt:
+    name:
+      - python3-virtualenv
+    state: latest
 
 - name: Install ntp
   when: openwisp2_install_ntp

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -15,8 +15,7 @@
   when: item != false
 
 - name: Add network_topology to custom package list if set and enabled
-  set_fact:
-    openwisp2_python_packages:"{{ openwisp2_python_packages + [item] }}"
+  set_fact: openwisp2_python_packages:"{{ openwisp2_python_packages + [item] }}"
   with_items:
     - "{{ openwisp2_django_netjsongraph_pip }}"
     - "{{ openwisp2_network_topology_pip }}"
@@ -24,28 +23,25 @@
 
 - name: Update pip & related tools
   pip:
-    name: "{{ item }}"
+    name:
+      - pip
+      - setuptools
+      - wheel
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
     virtualenv_site_packages: yes
-  with_items:
-    - pip
-    - setuptools
-    - wheel
 
 - name: Install openwisp2 controller and its dependencies
   pip:
-    name: "{{ item }}"
+    name:
+      - openwisp-controller
+      - asgi_redis
+      - service_identity
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
     virtualenv_site_packages: yes
-  with_items:
-    - openwisp-controller
-    # add asgi_redis for websockets
-    - asgi_redis
-    - service_identity
   notify: reload supervisor
 
 - name: Install django-redis
@@ -60,13 +56,12 @@
 - name: Install openwisp2 network topology and its dependencies
   when: openwisp2_network_topology
   pip:
-    name: "{{ item }}"
+    name:
+      - openwisp-network-topology
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
     virtualenv_site_packages: yes
-  with_items:
-    - openwisp-network-topology
   notify: reload supervisor
 
 - name: Install custom OpenWISP 2 Python packages
@@ -76,9 +71,8 @@
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
     virtualenv_site_packages: yes
+  with_items: "{{ openwisp2_python_packages }}"
   notify: reload supervisor
-  with_items:
-    - "{{ openwisp2_python_packages }}"
 
 - name: Install extra python packages
   pip:
@@ -92,13 +86,13 @@
 
 - name: Install uwsgi
   pip:
-    name: "{{ item }}"
+    name:
+      - uwsgi
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
     virtualenv_site_packages: yes
-  with_items:
-    - uwsgi
+
   notify: reload supervisor
 
 - name: Install psycopg2


### PR DESCRIPTION
The deprecation warnings referenced in the issue are not present anymore, but there were other warnings, which I fixed.

Ansible gives deprecation warnings for the "apt" and "pip" tasks. For example: 
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of
using a loop to supply multiple items and specifying `name: {{ item }}`, please use `name: ['sudo', 'software-
properties-common', 'build-essential', 'supervisor', 'nginx', 'openssl', 'libssl-dev', 'libffi-dev', 'python-dev',
'redis-server']` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg
```

Now, the log is free of any deprecation warnings.

Tests run using `tests/runtests.sh` pass.

Fixes #86