### PR TITLE
[qa] Fix Travis CI build errors #93

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,6 @@ env:
   - distro: 'ubuntu:18.04'
     playbook: test_networktopology.yml
 
-matrix:
-  allow_failures:
-    - env: distro=debian:10 playbook=test.yml
-    - env: distro=fedora:28 playbook=test.yml
-
 script:
   # Configure test script so we can run extra tests after playbook is run.
   - export container_id=$(date +%s)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Substitute `openwisp2.mydomain.com` with your **production server**'s hostname -
 `openwisp2.mydomain.com` WITH AN IP ADDRESS**, otherwise email sending through postfix will break,
 causing 500 internal server errors on some operations.
 
+If you are trying to deploy to a server running **Fedora 28** or newer, it is necessary to add
+`ansible_python_interpreter=/usr/bin/python3` to the end of the hostname.
+
+    [openwisp2]
+    openwisp2.mydomain.com ansible_python_interpreter=/usr/bin/python3
+
 Create playbook file
 --------------------
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,9 +23,12 @@ galaxy_info:
     versions:
     - trusty
     - xenial
+    - bionic
   - name: Fedora
     versions:
     - 25
+    - 27
+    - 28
   - name: EL
     versions:
     - 7

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -15,6 +15,7 @@
       - libffi-dev
       - python-dev
       - redis-server
+      - cron
     state: latest
   notify:
     - reload systemd

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -32,6 +32,14 @@
     virtualenv_python: "{{ openwisp2_python }}"
     virtualenv_site_packages: yes
 
+- name: Install cryptography from pip
+  pip:
+    name: cryptography
+    state: latest
+    virtualenv: "{{ virtualenv_path }}"
+    virtualenv_python: "{{ openwisp2_python }}"
+    virtualenv_site_packages: yes
+
 - name: Install openwisp2 controller and its dependencies
   pip:
     name:

--- a/tasks/variables-spatialite.yml
+++ b/tasks/variables-spatialite.yml
@@ -1,9 +1,11 @@
-- name: Set spatialite_path for Fedora
+- name: Set spatialite_path for Fedora <= 27
   set_fact:
     openwisp2_spatialite_path: "mod_spatialite"
-  when: ansible_distribution == 'Fedora'
+  when: >
+    (ansible_distribution == 'Fedora'
+    and ansible_distribution_version is version_compare('27', 'le'))
 
-- name: Set spatialite_path (Ubuntu >= 18.04 or Debian >= 10)
+- name: Set spatialite_path (Ubuntu >= 18.04 or Debian >= 10 or Fedora >= 28)
   set_fact:
     openwisp2_spatialite_path: "mod_spatialite.so"
   when: >
@@ -11,6 +13,8 @@
     and ansible_distribution_version is version_compare('18.04', 'ge')) 
     or (ansible_distribution == 'Debian' and 
     ansible_distribution_version is version_compare('10', 'ge'))
+    or (ansible_distribution == 'Fedora' and
+    ansible_distribution_version is version_compare('28', 'ge'))
 
 - name: Set spatialite_path (Ubuntu >= 16.04 or Debian >= 9)
   set_fact:

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -7,7 +7,7 @@
 
 - name: Install system packages
   package: name={{ item }} state=latest
-  notify: 
+  notify:
     - reload systemd
     - start redis
   with_items:
@@ -20,9 +20,26 @@
     - libffi-devel
     - python-devel
     - redis
+    - redhat-rpm-config
+    - cronie
+
+- name: Install python2 system packages
+  when: ansible_python_interpreter == "/usr/bin/python"
+  package: name={{ item }} state=latest
+  notify:
+    - reload systemd
+  with_items:
     - libsemanage-python
     - policycoreutils-python
-    - redhat-rpm-config
+
+- name: Install python3 system packages
+  when: ansible_python_interpreter == "/usr/bin/python3"
+  package: name={{ item }} state=latest
+  notify:
+    - reload systemd
+  with_items:
+    - libsemanage-python3
+    - policycoreutils-python3
 
 # On the newer versions of redis, by default redis
 # binds to localhost on ipv6 address which wouldn't
@@ -36,13 +53,24 @@
     line: 'bind 127.0.0.1'
     backrefs: yes
 
-- name: Install firewall packages
+# Fedora 28 and above drops the package python-firewall
+# and it gets replaced by python3-firewall
+
+- name: Install python2 firewall packages
+  when: ansible_python_interpreter == "/usr/bin/python"
   package: name={{ item }} state=present
   notify: reload systemd
   with_items:
     - python-firewall
     - firewalld
-  when: ansible_distribution_major_version|int >= 7
+
+- name: Install python3 firewall packages
+  when: ansible_python_interpreter == "/usr/bin/python3"
+  package: name={{ item }} state=present
+  notify: reload systemd
+  with_items:
+    - python3-firewall
+    - firewalld
 
 - name: Install spatialite
   when: openwisp2_database.engine == "django.contrib.gis.db.backends.spatialite"

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,14 +1,101 @@
 #!/bin/bash
-set -e 
 
-# Download snippet
-echo "Downloading common tests shim..."
-wget -q -O ${PWD}/tests/test.sh https://gitlab.com/snippets/1751673/raw
-chmod +x ${PWD}/tests/test.sh
+# Exit on any individual command failure.
+set -e
 
-# Run tests
-echo "Running script test.sh"
-${PWD}/tests/test.sh
+# Pretty colors.
+red='\033[0;31m'
+green='\033[0;32m'
+neutral='\033[0m'
+
+timestamp=$(date +%s)
+
+# Allow environment variables to override defaults.
+distro=${distro:-"centos:7"}
+playbook=${playbook:-"test.yml"}
+ansible_opts=${ansible_opts:-"ansible_python_interpreter=/usr/bin/python"}
+role_dir=${role_dir:-"$PWD"}
+cleanup=${cleanup:-"true"}
+container_id=${container_id:-$timestamp}
+test_idempotence=${test_idempotence:-"true"}
+
+## Set up vars for Docker setup.
+# CentOS 7
+if [ $distro = 'centos:7' ]; then
+  init="/usr/lib/systemd/systemd"
+  opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+# Ubuntu 18.04
+elif [ $distro = 'ubuntu:18.04' ]; then
+  init="/lib/systemd/systemd"
+  opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+# Ubuntu 16.04
+elif [ $distro = 'ubuntu:16.04' ]; then
+  init="/lib/systemd/systemd"
+  opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+# Debian 10
+elif [ $distro = 'debian:10' ]; then
+  init="/lib/systemd/systemd"
+  opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+# Debian 9
+elif [ $distro = 'debian:9' ]; then
+  init="/lib/systemd/systemd"
+  opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+# Debian 8
+elif [ $distro = 'debian:8' ]; then
+  init="/lib/systemd/systemd"
+  opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+# Fedora 27
+elif [ $distro = 'fedora:27' ]; then
+  init="/usr/lib/systemd/systemd"
+  opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+# Fedora 28
+elif [ $distro = 'fedora:28' ]; then
+  init="/usr/lib/systemd/systemd"
+  opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  ansible_opts="ansible_python_interpreter=/usr/bin/python3"
+fi
+
+# Run the container using the supplied OS
+printf ${green}"Starting Docker container: registry.gitlab.com/ninuxorg/docker/ansible-$distro"${neutral}"\n"
+docker pull registry.gitlab.com/ninuxorg/docker/ansible-$distro
+docker run --detach --volume="$role_dir":/etc/ansible/roles/role_under_test:rw --name $container_id $opts registry.gitlab.com/ninuxorg/docker/ansible-$distro $init
+
+printf "\n"
+
+# Install requirements if `requirements.yml` is present
+if [ -f "$role_dir/tests/requirements.yml" ]; then
+  printf ${green}"Requirements file detected; installing dependencies"${neutral}"\n"
+  docker exec --tty $container_id env TERM=xterm ansible-galaxy install -r /etc/ansible/roles/role_under_test/tests/requirements.yml
+fi
+
+printf "\n"
+
+# Test Ansible syntax.
+printf ${green}"Checking Ansible playbook syntax"${neutral}
+docker exec --tty $container_id env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/$playbook --syntax-check
+
+printf "\n"
+
+# Run Ansible playbook
+printf ${green}"Running command: docker exec $container_id env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/$playbook"${neutral}
+docker exec $container_id env TERM=xterm env ANSIBLE_FORCE_COLOR=1 ansible-playbook /etc/ansible/roles/role_under_test/tests/$playbook -e $ansible_opts
+
+if [ "$test_idempotence" = true ]; then
+  # Run Ansible playbook again (idempotence test).
+  printf ${green}"Running playbook again: idempotence test"${neutral}
+  idempotence=$(mktemp)
+  docker exec $container_id  env TERM=xterm env ANSIBLE_FORCE_COLOR=1 ansible-playbook /etc/ansible/roles/role_under_test/tests/$playbook -e $ansible_opts --diff | tee -a $idempotence
+  tail $idempotence \
+    | grep -q 'changed=0.*failed=0' \
+    && (printf ${green}'Idempotence test: pass'${neutral}"\n") \
+    || (printf ${red}'Idempotence test: fail'${neutral}"\n" && exit 1)
+fi
+
+# Remove the Docker container (if configured).
+if [ "$cleanup" = true ]; then
+  printf "Removing Docker container...\n"
+  docker rm -f $container_id
+fi
 
 # Check OpenWISP is running
 echo "Lauching OpenWISP tests"


### PR DESCRIPTION
Travis CI builds for Debian 9, Debian 10, and Fedora 28 have been fixed. 
- Python3 is set as the `ansible_python_interpreter` for Fedora 28 because it drops support for `python-firewall` which is for Python2. 
- Cron is also added to `apt.yml` to resolve errors in Debian 10. 
- Additionally, `cryptography` from pip is installed to fix an odd SSL error when installing `django-redis` on Debian 9.
- The `spatialite_path` is updated for Fedora 28