### PR TITLE
[django] Removed automatic organization creation #95

### DIFF
--- a/templates/load_initial_data.py
+++ b/templates/load_initial_data.py
@@ -21,22 +21,6 @@ if User.objects.filter(is_superuser=True).count() < 1:
                                           email='')
     print('superuser created')
 
-if 'openwisp_users' in settings.INSTALLED_APPS:
-    from openwisp_users.models import Organization
-
-    if Organization.objects.count() < 1:
-        options = dict(id='{{ openwisp2_default_organization_id }}',
-                       name='default',
-                       slug='default')
-        org = Organization.objects.create(**options)
-
-        if 'openwisp_controller.config' in settings.INSTALLED_APPS:
-            from openwisp_controller.config.models import OrganizationConfigSettings
-
-            OrganizationConfigSettings.objects.create(organization=org,
-                                                      registration_enabled=True)
-        print('default organization created')
-
 if 'django.contrib.sites' in settings.INSTALLED_APPS:
     from django.contrib.sites.models import Site
     site = Site.objects.first()


### PR DESCRIPTION
Removed few lines from  templates/load_initial_data.py which were meant to create a default organization in favor of data migration