### PR TITLE
[pip] Fix condition

### DIFF
--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -12,7 +12,7 @@
     - "{{ openwisp2_django_x509_pip }}"
     - "{{ openwisp2_django_loci_pip }}"
     - "{{ openwisp2_netjsonconfig_pip }}"
-  when: item
+  when: item != False
 
 - name: Add network_topology to custom package list if set and enabled
   set_fact: openwisp2_python_packages:"{{ openwisp2_python_packages + [item] }}"


### PR DESCRIPTION
ansible 2.7.5 didn't accept https://github.com/openwisp/ansible-openwisp2/blob/f807dce65419a37d5111e324ce1b91163120e3f3/tasks/pip.yml#L15 here. So I improved that line. And it makes sense to use to `!=False` because those `openwisp2_*_pip` always exist through https://github.com/openwisp/ansible-openwisp2/blob/master/defaults/main.yml.
Additionally I improved the code formatting.