### PR TITLE
[nginx] Add a default server block that returns 404

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -20,6 +20,11 @@
     warn: False
   notify: restart nginx
 
+- name: disable default nginx configuration
+  file:
+   path: "/etc/nginx/sites-enabled/default"
+   state: absent
+
 - name: nginx site available
   template:
     src: nginx.j2

--- a/templates/nginx.j2
+++ b/templates/nginx.j2
@@ -128,3 +128,24 @@ server {
     {% endif %}
 
 }
+
+server {
+    listen 80 default_server;
+    {% if openwisp2_nginx_ipv6 %}listen [::]:80 default_server; # ipv6{% endif %}
+
+    server_name _;
+
+    return 404;
+}
+
+server {
+    listen 443 ssl default_server;
+    {% if openwisp2_nginx_ipv6 %}listen [::]:443 ssl default_server; # ipv6{% endif %}
+    server_name _;
+
+    ssl on;
+    ssl_certificate {{ openwisp2_ssl_cert }};
+    ssl_certificate_key {{ openwisp2_ssl_key }};
+
+    return 404;
+}


### PR DESCRIPTION
- A new, default Nginx server block that returns 404 is added for requests that do not match accepted hostnames
- The symlink at `/etc/nginx/sites-enabled/default` is removed to disable the default Nginx configuration, so there is only one `default_server` defined per port

Closes #135