### PR TITLE
[pip + tests] Fix Ansible deprecation warning and minor issues

### DIFF
--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -16,7 +16,8 @@
   when: item | bool
 
 - name: Add network_topology to custom package list if set and enabled
-  set_fact: openwisp2_python_packages:"{{ openwisp2_python_packages + [item] }}"
+  set_fact:
+    openwisp2_python_packages: "{{ openwisp2_python_packages + [item] }}"
   with_items:
     - "{{ openwisp2_django_netjsongraph_pip }}"
     - "{{ openwisp2_network_topology_pip }}"
@@ -81,8 +82,7 @@
 - name: Install openwisp2 network topology and its dependencies
   when: openwisp2_network_topology
   pip:
-    name:
-      - openwisp-network-topology
+    name: openwisp-network-topology
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
@@ -94,13 +94,13 @@
   until: result is success
 
 - name: Install custom OpenWISP 2 Python packages
+  when: openwisp2_python_packages
   pip:
-    name: "{{ item }}"
+    name: "{{ openwisp2_python_packages }}"
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
     virtualenv_site_packages: yes
-  with_items: "{{ openwisp2_python_packages }}"
   notify: reload supervisor
   retries: 5
   delay: 10
@@ -122,8 +122,7 @@
 
 - name: Install uwsgi
   pip:
-    name:
-      - uwsgi
+    name: uwsgi
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -109,12 +109,11 @@
 
 - name: Install extra python packages
   pip:
-    name: "{{ item }}"
+    name: "{{ openwisp2_extra_python_packages }}"
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
     virtualenv_site_packages: yes
-  with_items: "{{ openwisp2_extra_python_packages }}"
   retries: 5
   delay: 10
   register: result

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -92,7 +92,7 @@ if [ "$test_idempotence" = true ]; then
 fi
 
 # Check OpenWISP is running
-echo "Lauching OpenWISP tests"
+echo "Launching OpenWISP tests"
 docker exec "${container_id}" curl --insecure -s --head https://localhost/admin/login/?next=/admin/ \
  | sed -n "1p" | grep -q "200" \
  && (printf "Status code 200 test: pass\n" && exit 0) \

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -4,9 +4,9 @@
 set -e
 
 # Pretty colors.
-red='\033[0;31m'
-green='\033[0;32m'
-neutral='\033[0m'
+red="\033[0;31m"
+green="\033[0;32m"
+neutral="\033[0m"
 
 timestamp=$(date +%s)
 
@@ -21,35 +21,35 @@ test_idempotence=${test_idempotence:-"true"}
 
 ## Set up vars for Docker setup.
 # CentOS 7
-if [ $distro = 'centos:7' ]; then
+if [ $distro = "centos:7" ]; then
   init="/usr/lib/systemd/systemd"
   opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 # Ubuntu 18.04
-elif [ $distro = 'ubuntu:18.04' ]; then
+elif [ $distro = "ubuntu:18.04" ]; then
   init="/lib/systemd/systemd"
   opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 # Ubuntu 16.04
-elif [ $distro = 'ubuntu:16.04' ]; then
+elif [ $distro = "ubuntu:16.04" ]; then
   init="/lib/systemd/systemd"
   opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 # Debian 10
-elif [ $distro = 'debian:10' ]; then
+elif [ $distro = "debian:10" ]; then
   init="/lib/systemd/systemd"
   opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 # Debian 9
-elif [ $distro = 'debian:9' ]; then
+elif [ $distro = "debian:9" ]; then
   init="/lib/systemd/systemd"
   opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 # Debian 8
-elif [ $distro = 'debian:8' ]; then
+elif [ $distro = "debian:8" ]; then
   init="/lib/systemd/systemd"
   opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 # Fedora 27
-elif [ $distro = 'fedora:27' ]; then
+elif [ $distro = "fedora:27" ]; then
   init="/usr/lib/systemd/systemd"
   opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 # Fedora 28
-elif [ $distro = 'fedora:28' ]; then
+elif [ $distro = "fedora:28" ]; then
   init="/usr/lib/systemd/systemd"
   opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
   ansible_opts="ansible_python_interpreter=/usr/bin/python3"
@@ -86,15 +86,9 @@ if [ "$test_idempotence" = true ]; then
   idempotence=$(mktemp)
   docker exec $container_id  env TERM=xterm env ANSIBLE_FORCE_COLOR=1 ansible-playbook /etc/ansible/roles/role_under_test/tests/$playbook -e $ansible_opts --diff | tee -a $idempotence
   tail $idempotence \
-    | grep -q 'changed=0.*failed=0' \
-    && (printf ${green}'Idempotence test: pass'${neutral}"\n") \
-    || (printf ${red}'Idempotence test: fail'${neutral}"\n" && exit 1)
-fi
-
-# Remove the Docker container (if configured).
-if [ "$cleanup" = true ]; then
-  printf "Removing Docker container...\n"
-  docker rm -f $container_id
+    | grep -q "changed=0.*failed=0" \
+    && (printf ${green}"Idempotence test: pass"${neutral}"\n") \
+    || (printf ${red}"Idempotence test: fail"${neutral}"\n" && exit 1)
 fi
 
 # Check OpenWISP is running
@@ -150,3 +144,9 @@ docker exec "${container_id}" \
         openwisp_controller.config.tests.test_admin.TestAdmin.test_vpn_not_contains_default_templates_js \
         openwisp_controller.geo.tests.test_channels \
         openwisp_controller.geo.tests.test_api
+
+# Remove the Docker container (if configured).
+if [ "$cleanup" = true ]; then
+  printf "Removing Docker container...\n"
+  docker rm -f $container_id
+fi


### PR DESCRIPTION
- The deprecation warning from Ansible in the `Install extra python packages` task is fixed
- Package names are moved to the same line as `name:` if there is only one package installed
- Single quotes are replaced with double quotes to maintain consistency with the rest of the code
- Changed `Lauching` to `Launching` in `tests/runtests.sh`
- The removal of the Docker container is moved to the end of the `tests/runtests.sh` script
```
Removing Docker container...
1570316059
Lauching OpenWISP tests
Error: No such container: 1570316059
Status code 200 test: fail
Error: No such container: 1570316059
```
If this is not desired, it can exit before running the tests instead:
```bash
# Remove the Docker container (if configured).
if [ "$cleanup" = true ]; then
  printf "Removing Docker container...\n"
  docker rm -f $container_id
  exit 0
fi
```

Fixes #126 