### PR TITLE
[bug] Reload systemd only if host have it #131

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,7 @@
 
 - name: reload systemd
   systemd: daemon_reload=yes
-  when: ansible_distribution_release in ['xenial', 'bionic']
+  when: ansible_distribution_release in ['xenial', 'bionic'] and ansible_service_mgr == 'systemd'
 
 - name: reload supervisor
   command: supervisorctl reload


### PR DESCRIPTION
Reload systemd only if host is running on it.

Tested on devuan linux (debian without systemd)
Fixes #131