### PR TITLE
[qa] Replace with openwisp-utils-qa-checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,15 +44,8 @@ script:
   - ansible-lint tests/test_networktopology.yml
   # run ci tests
   - ${PWD}/tests/runtests.sh
-  - pip install --user https://github.com/openwisp/openwisp-utils/tarball/master
-  - |
-    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-      # gets commit message of last commit before pull request merge
-      COMMIT_MESSAGE=$(git log $TRAVIS_PULL_REQUEST_SHA --format=%B -n 1)
-      printf "Checking commit message:\n\n"
-      printf "$COMMIT_MESSAGE\n\n"
-      checkcommit --message "$COMMIT_MESSAGE"
-    fi
+  - pip install --user "openwisp-utils[qa]>=0.3.1"
+  - openwisp-utils-qa-checks --skip-isort --skip-flake8 --skip-checkmigrations
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/


### PR DESCRIPTION
Replace old qa checks with `openwisp-utils-qa-checks` (related to openwisp/openwisp-utils#63 for this repo)