### PR TITLE
[gsoc2020] Merged Modules remove django-netjsongraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ Below are listed all the variables you can customize (you may also want to take 
     openwisp2_controller_version: "0.4"
     # optional openwisp2 modules
     openwisp2_network_topology: false
-    openwisp2_network_topology_version: "0.2"
+    openwisp2_network_topology_version: "0.4"
     # you may replace the values of these variables with any URL
     # supported by pip (the python package installer)
     # use these to install forks, branches or development versions
@@ -555,7 +555,6 @@ Below are listed all the variables you can customize (you may also want to take 
     openwisp2_django_x509_pip: false
     openwisp2_netjsonconfig_pip: false
     openwisp2_network_topology_pip: false
-    openwisp2_django_netjsongraph_pip: false
     # by default python3 is used, if may need to set this to python2.7 for older systems
     openwisp2_python: python2.7
     # customize the app_path

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 openwisp2_python: python3
 openwisp2_network_topology: false
 openwisp2_controller_version: "0.7.post1"
-openwisp2_network_topology_version: "0.3"
+openwisp2_network_topology_version: "0.4"
 openwisp2_controller_pip: false
 openwisp2_users_pip: false
 openwisp2_utils_pip: false
@@ -10,7 +10,6 @@ openwisp2_django_x509_pip: false
 openwisp2_django_loci_pip: false
 openwisp2_netjsonconfig_pip: false
 openwisp2_network_topology_pip: false
-openwisp2_django_netjsongraph_pip: false
 openwisp2_extra_python_packages: [bpython]
 openwisp2_extra_django_apps: []
 openwisp2_extra_django_settings: {}

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -27,15 +27,14 @@
     - "{{ openwisp2_django_x509_pip }}"
     - "{{ openwisp2_django_loci_pip }}"
     - "{{ openwisp2_netjsonconfig_pip }}"
-  when: item is defined and item
+  when: item is defined and item is string
 
 - name: Add network_topology to custom package list if set and enabled
   set_fact:
     openwisp2_python_packages: "{{ openwisp2_python_packages + [item] }}"
   with_items:
-    - "{{ openwisp2_django_netjsongraph_pip }}"
     - "{{ openwisp2_network_topology_pip }}"
-  when: item and openwisp2_network_topology
+  when: item is defined and item is string and openwisp2_network_topology
 
 - name: Update pip & related tools
   pip:
@@ -124,7 +123,7 @@
   notify: reload supervisor
 
 - name: Install custom OpenWISP 2 Python packages
-  when: openwisp2_python_packages
+  when: openwisp2_python_packages|length > 0
   pip:
     name: "{{ openwisp2_python_packages }}"
     state: latest

--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -65,9 +65,6 @@ EXTENDED_APPS = [
     'django_netjsonconfig',
     'django_x509',
     'django_loci',
-{% if openwisp2_network_topology %}
-    'django_netjsongraph',
-{% endif %}
 ]
 
 AUTH_USER_MODEL = 'openwisp_users.User'


### PR DESCRIPTION
Blocked by `openwisp-network-topology release` after https://github.com/openwisp/openwisp-network-topology/issues/66