### PR TITLE
[fix] Bind channels_redis to 2.4

### DIFF
--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -68,7 +68,7 @@
   pip:
     name:
       - "openwisp-controller~={{ openwisp2_controller_version }}"
-      - channels_redis
+      - channels_redis~=2.4
       - service_identity
     state: latest
     virtualenv: "{{ virtualenv_path }}"


### PR DESCRIPTION
channels_redis 3.x requires redis 5.