### PR TITLE
[fix] Write daphne socket file to openwisp2_path

### DIFF
--- a/templates/supervisor/daphne.j2
+++ b/templates/supervisor/daphne.j2
@@ -2,7 +2,7 @@
 user={{ www_user }}
 socket=tcp://localhost:8000
 directory={{ openwisp2_path }}
-command={{ openwisp2_path }}/env/bin/daphne --fd 0 -u /run/daphne%(process_num)d.sock --access-log - --proxy-headers openwisp2.asgi:application
+command={{ openwisp2_path }}/env/bin/daphne --fd 0 -u {{ openwisp2_path }}/daphne%(process_num)d.sock --access-log - --proxy-headers openwisp2.asgi:application
 process_name=asgi%(process_num)d
 numprocs=3
 autostart=true


### PR DESCRIPTION
Fixes a regression introduced in 17a9099
www-data does not have permissions to write to /run/,
hence we write this file to {{ openwisp2_path }}