### PR TITLE
[feat] Added support for Ubuntu 20.04 (#189)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - ROLE_NAME: openwisp2
   jobs:
     - MOLECULE_DISTRO: ubuntu1804
+    - MOLECULE_DISTRO: ubuntu2004
     - MOLECULE_DISTRO: debian10
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ From here on you can follow the instructions available at the following sections
 
 **Note:** Please remember to [install ansible](#install-ansible).
 
+**ProTip:** Use `molecule test --destroy=never` to speed up between each run.
+
 All done!
 
 How to run tests

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 openwisp2_python: python3
+ansible_python_interpreter: /usr/bin/python3
 openwisp2_network_topology: false
 openwisp2_controller_version: "0.7.post1"
 openwisp2_network_topology_version: "0.4"

--- a/files/generate_django_secret_key.py
+++ b/files/generate_django_secret_key.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Pseudo-random django secret key generator
 """

--- a/files/generate_django_secret_key.py
+++ b/files/generate_django_secret_key.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Pseudo-random django secret key generator
 """

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -27,6 +27,7 @@ galaxy_info:
     # https://github.com/openwisp/ansible-openwisp2/issues/169#issuecomment-592983139
     # - xenial
     - bionic
+    - focal
   # we don't have the resources now to maintain these distros
   # - name: Fedora
   #   versions:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,7 +8,7 @@
     openwisp2_network_topology: true
 
   pre_tasks:
-    - name: Update apt cache.
+    - name: Update apt cache
       apt: update_cache=true cache_valid_time=600
       when: ansible_os_family == 'Debian'
 

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -17,17 +17,32 @@
       - openssl
       - libssl-dev
       - libffi-dev
-      - python-dev
-      - redis-server
+      - python3
+      - virtualenv
       - cron
-  notify:
-    - reload systemd
-    - start redis
   ignore_errors: yes
   retries: 5
   delay: 10
   register: result
   until: result is success
+
+- name: Install redis 5 if available
+  apt:
+    name: "redis-server=5:5*"
+  notify:
+    - reload systemd
+    - start redis
+  ignore_errors: yes
+  register: use_redis5
+
+- name: Install redis 4 (fallback)
+  when: use_redis5.failed
+  apt:
+    name: "redis-server=5:4*"
+  notify:
+    - reload systemd
+    - start redis
+  ignore_errors: yes
 
 # On the newer versions of redis, by default redis
 # binds to localhost on ipv6 address which wouldn't
@@ -91,33 +106,11 @@
   until: result is success
 
 - name: Install python3 packages
-  when: openwisp2_python == "python3"
   apt:
     name:
-      - python3
       - python3-pip
       - python3-dev
-      - python-virtualenv
-  retries: 5
-  delay: 10
-  register: result
-  until: result is success
-
-- name: Install python wheel (optional, allowed to fail)
-  ignore_errors: yes
-  apt:
-    name:
-      - python-wheel
-      - python3-wheel
-  retries: 1
-  delay: 10
-  register: result
-  until: result is success
-
-- name: Install python3-virtualenv
-  ignore_errors: yes
-  when: ansible_distribution != 'Ubuntu'
-  apt: name=python3-virtualenv
+      - python3-virtualenv
   retries: 5
   delay: 10
   register: result

--- a/tasks/django.yml
+++ b/tasks/django.yml
@@ -108,6 +108,8 @@
     # sets executable only to directories
     mode: u=rwX,g=rX,o=rX
     recurse: yes
+  tags:
+    - molecule-idempotence-notest
 
 - name: collectstatic
   notify: reload supervisor

--- a/tasks/django_secret_key.yml
+++ b/tasks/django_secret_key.yml
@@ -5,7 +5,7 @@
     mode: 0754
 
 - name: generate new django SECRET_KEY
-  shell: "./generate_django_secret_key.py > .django-secret-key"
+  shell: "{{ virtualenv_path }}/bin/python ./generate_django_secret_key.py > .django-secret-key"
   args:
     chdir: "{{ openwisp2_path }}"
     creates: "{{ openwisp2_path }}/.django-secret-key"

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -1,3 +1,19 @@
+- name: Update pip & related tools
+  pip:
+    name:
+      - pip
+      - setuptools
+      - wheel
+      - attrs
+    state: latest
+    virtualenv: "{{ virtualenv_path }}"
+    virtualenv_python: "{{ openwisp2_python }}"
+    virtualenv_site_packages: yes
+  retries: 5
+  delay: 10
+  register: result
+  until: result is success
+
 - name: Remove jsonfield2
   pip:
     name:
@@ -36,22 +52,6 @@
     - "{{ openwisp2_network_topology_pip }}"
   when: item is defined and item is string and openwisp2_network_topology
 
-- name: Update pip & related tools
-  pip:
-    name:
-      - pip
-      - setuptools
-      - wheel
-      - attrs
-    state: latest
-    virtualenv: "{{ virtualenv_path }}"
-    virtualenv_python: "{{ openwisp2_python }}"
-    virtualenv_site_packages: yes
-  retries: 5
-  delay: 10
-  register: result
-  until: result is success
-
 - name: Install cryptography from pip
   pip:
     name: cryptography
@@ -68,13 +68,29 @@
   pip:
     name:
       - "openwisp-controller~={{ openwisp2_controller_version }}"
-      - channels_redis~=2.4
+      - channels_redis
       - service_identity
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
     virtualenv_site_packages: yes
   notify: reload supervisor
+  retries: 5
+  delay: 10
+  register: result
+  until: result is success
+  tags:
+    - molecule-idempotence-notest
+
+- name: Pin channels_redis to 2.4 for redis 4 compatibility
+  when: use_redis5.failed
+  pip:
+    name:
+      - channels_redis~=2.4
+    state: latest
+    virtualenv: "{{ virtualenv_path }}"
+    virtualenv_python: "{{ openwisp2_python }}"
+    virtualenv_site_packages: yes
   retries: 5
   delay: 10
   register: result


### PR DESCRIPTION
(this PR integrates the work done in #190)

- switched to use /usr/bin/python3 by default
- python-virtualenv > python3-virtualenv
- build in travis using ubuntu 20.04
- add ubuntu 20.04 (focal) to meta info
- handle redis 4/5 and dependencies
- removed step to install python-wheel (installed by pip later)
- simplified python3-virtualenv installation
- pin channels_redis to 2.4 for redis 4 compatibility

Closes #189