### PR TITLE
[fix] install molecule using docker driver and updated README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
 
 install:
   # Install test dependencies.
-  - pip install molecule yamllint ansible-lint docker openwisp-utils[qa]
+  - pip install molecule[docker] yamllint ansible-lint docker openwisp-utils[qa]
 
 script:
   # Run tests.

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ If you haven't installed docker yet, you need to install it (example for linux d
 
 **Step 3**: Install molecule and dependences
 
-    pip install molecule yamllint ansible-lint docker
+    pip install molecule[docker] yamllint ansible-lint docker
 
 **Step 4**: Download docker images
 


### PR DESCRIPTION
Fix molecule v3.1.1 regression: {'driver': [{'name': ['unallowed value docker']}]}