### PR TITLE
[feature] Added support for openwisp_notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,9 @@ Substitute `openwisp2.mydomain.com` with your production server's hostname.
 Now proceed with the following steps:
 
 1. change the password (and the username if you like) of the superuser as soon as possible
-2. edit the information of the default organization
-3. in the default organization you just updated, note down the automatically generated *shared secret*
+2. update the `name` field of the default `Site` object to accurately display site name in email notifications
+3. edit the information of the default organization
+4. in the default organization you just updated, note down the automatically generated *shared secret*
    option, you will need it to use the [auto-registration feature of openwisp-config](https://github.com/openwisp/openwisp-config#automatic-registration)
 
 Now you are ready to start configuring your network! **If you need help** you can ask questions
@@ -536,6 +537,8 @@ Below are listed all the variables you can customize (you may also want to take 
     openwisp2_controller_pip: false
     openwisp2_users_pip: false
     openwisp2_utils_pip: false
+    openwisp2_notifications_pip: false
+    openwisp2_django_netjsonconfig_pip: false
     openwisp2_django_x509_pip: false
     openwisp2_netjsonconfig_pip: false
     openwisp2_network_topology_pip: false
@@ -654,6 +657,8 @@ Below are listed all the variables you can customize (you may also want to take 
     openwisp2_celery_broker_url: redis://127.0.0.1:6379/3
     openwisp2_celery_worker_prefetch_multiplier: 1
     openwisp2_celery_task_acks_late: True
+    # maximum number of retries by celery before giving up when broker is unreachable
+    openwisp2_celery_broker_max_tries: 10
     # whether to activate the django logging configuration in celery
     # if set to True, will log all the celery events in the same log stream used by django
     # which will cause log lines to be written to "{{ openwisp2_path }}/log/openwisp2.log"
@@ -663,6 +668,8 @@ Below are listed all the variables you can customize (you may also want to take 
     postfix_smtp_sasl_auth_enable_override: yes
     # allow overriding postfix_smtpd_relay_restrictions
     postfix_smtpd_relay_restrictions_override: permit_mynetworks
+    # allows overriding the default duration for keeping notifications
+    openwisp2_notifications_delete_old_notifications: 10
 ```
 
 Support

--- a/README.md
+++ b/README.md
@@ -538,7 +538,6 @@ Below are listed all the variables you can customize (you may also want to take 
     openwisp2_users_pip: false
     openwisp2_utils_pip: false
     openwisp2_notifications_pip: false
-    openwisp2_django_netjsonconfig_pip: false
     openwisp2_django_x509_pip: false
     openwisp2_netjsonconfig_pip: false
     openwisp2_network_topology_pip: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,6 +51,7 @@ openwisp2_sentry:
 openwisp2_default_cert_validity: 1825
 openwisp2_default_ca_validity: 3650
 openwisp2_default_organization_id: 78f74fdd-67c6-4064-97e1-ce761da30745
+openwisp2_notifications_delete_old_notifications: 90
 openwisp2_topology_update_frequency:
     day: "*"
     hour: "*"
@@ -83,5 +84,6 @@ openwisp2_celery_concurrency: "{{ openwisp2_eventlet_concurrency | default(10) }
 openwisp2_celery_broker_url: redis://127.0.0.1:6379/3
 openwisp2_celery_worker_prefetch_multiplier: 1
 openwisp2_celery_task_acks_late: True
+openwisp2_celery_broker_max_tries: 10
 openwisp2_django_celery_logging: False
 postfix_smtpd_relay_restrictions_override: "permit_sasl_authenticated, permit_mynetworks, check_relay_domains, reject_unauth_destination, reject"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 openwisp2_python: python3
 ansible_python_interpreter: /usr/bin/python3
 openwisp2_network_topology: false
-openwisp2_controller_version: "0.8.0"
+openwisp2_controller_version: "0.8.1"
 openwisp2_network_topology_version: "0.5.1"
 openwisp2_controller_pip: false
 openwisp2_users_pip: false

--- a/molecule/resources/converge.yml
+++ b/molecule/resources/converge.yml
@@ -6,6 +6,11 @@
 
   vars:
     openwisp2_network_topology: true
+    # Remove when openwisp-controller==0.8 is released
+    openwisp2_controller_pip: https://github.com/openwisp/openwisp-controller/tarball/master
+    openwisp2_extra_python_packages:
+      - django-flat-json-widget
+      - https://github.com/openwisp/openwisp-notifications/tarball/master
 
   pre_tasks:
     - name: Update apt cache

--- a/molecule/resources/converge.yml
+++ b/molecule/resources/converge.yml
@@ -6,11 +6,6 @@
 
   vars:
     openwisp2_network_topology: true
-    # Remove when openwisp-controller==0.8 is released
-    openwisp2_controller_pip: https://github.com/openwisp/openwisp-controller/tarball/master
-    openwisp2_extra_python_packages:
-      - django-flat-json-widget
-      - https://github.com/openwisp/openwisp-notifications/tarball/master
 
   pre_tasks:
     - name: Update apt cache

--- a/molecule/resources/verify.yml
+++ b/molecule/resources/verify.yml
@@ -39,9 +39,7 @@
             openwisp_controller.config.tests.test_admin.TestAdmin.test_template_not_contains_default_templates_js \
             openwisp_controller.config.tests.test_admin.TestAdmin.test_vpn_not_contains_default_templates_js \
             openwisp_controller.config.tests.test_notifications \
-            openwisp_controller.connection.tests.test_notifications \
-            openwisp_controller.geo.tests.test_api \
-            openwisp_notifications.tests.test_admin
+            openwisp_controller.geo.tests.test_api
       changed_when: false
 
     - name: Check if redis-server is running

--- a/molecule/resources/verify.yml
+++ b/molecule/resources/verify.yml
@@ -38,7 +38,10 @@
             openwisp_controller.config.tests.test_admin.TestAdmin.test_device_contains_default_templates_js \
             openwisp_controller.config.tests.test_admin.TestAdmin.test_template_not_contains_default_templates_js \
             openwisp_controller.config.tests.test_admin.TestAdmin.test_vpn_not_contains_default_templates_js \
-            openwisp_controller.geo.tests.test_api
+            openwisp_controller.config.tests.test_notifications \
+            openwisp_controller.connection.tests.test_notifications \
+            openwisp_controller.geo.tests.test_api \
+            openwisp_notifications.tests.test_admin
       changed_when: false
 
     - name: Check if redis-server is running

--- a/tasks/complete.yml
+++ b/tasks/complete.yml
@@ -11,5 +11,3 @@
     msg: "Update the default site object at https://{{ inventory_hostname }}/admin/sites/site/1/change/"
   tags:
     - molecule-idempotence-notest
-
-

--- a/tasks/complete.yml
+++ b/tasks/complete.yml
@@ -4,3 +4,12 @@
     msg: "Change your admin password at https://{{ inventory_hostname }}/admin/password_change/"
   tags:
     - molecule-idempotence-notest
+
+- name: Update site object hint
+  when: '"created" in load_initial_data_result.stdout'
+  debug:
+    msg: "Update the default site object at https://{{ inventory_hostname }}/admin/sites/site/1/change/"
+  tags:
+    - molecule-idempotence-notest
+
+

--- a/tasks/django.yml
+++ b/tasks/django.yml
@@ -82,6 +82,17 @@
     group: "{{ www_group }}"
     mode: 0664
 
+- name: routing.py
+  notify: reload supervisor
+  template:
+    src: openwisp2/routing.py
+    dest: "{{ openwisp2_path }}/openwisp2/routing.py"
+    group: "{{ www_group }}"
+    mode: 0664
+
+- name: start redis
+  service: name=redis state=started
+
 - name: migrate
   notify: reload supervisor
   become: yes

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -37,6 +37,7 @@
     openwisp2_python_packages: "{{ openwisp2_python_packages + [item] }}"
   with_items:
     - "{{ openwisp2_controller_pip }}"
+    - "{{ openwisp2_notifications_pip }}"
     - "{{ openwisp2_users_pip }}"
     - "{{ openwisp2_utils_pip }}"
     - "{{ openwisp2_django_x509_pip }}"

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -26,6 +26,13 @@
     mode: 0644
   notify: reload supervisor
 
+- name: supervisor celerybeat
+  template:
+    src: supervisor/celerybeat.j2
+    dest: "{{ supervisor_path | format('celerybeat') }}"
+    mode: 0644
+  notify: reload supervisor
+
 - name: Remove supervisor runworker.conf (obsolete)
   file:
     dest: "{{ supervisor_path | format('runworker') }}"

--- a/templates/openwisp2/routing.py
+++ b/templates/openwisp2/routing.py
@@ -1,0 +1,13 @@
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
+
+from openwisp_controller.routing import get_routes
+
+application = ProtocolTypeRouter(
+    {
+        'websocket': AllowedHostsOriginValidator(
+            AuthMiddlewareStack(URLRouter(get_routes()))
+        )
+    }
+)

--- a/templates/supervisor/celerybeat.j2
+++ b/templates/supervisor/celerybeat.j2
@@ -1,0 +1,11 @@
+[program:celerybeat]
+user={{ www_user }}
+directory={{ openwisp2_path }}
+command={{ openwisp2_path }}/env/bin/celery -A openwisp2 beat -l info
+autostart=true
+autorestart=true
+stopsignal=INT
+redirect_stderr=true
+stdout_logfile={{ openwisp2_path }}/log/celerybeat.log
+stdout_logfile_maxbytes=30MB
+stdout_logfile_backups=5


### PR DESCRIPTION
 - [x] Added support for openwisp_notifications integration in openwisp_controller
 - [x] Updated docs to ask user to update Site object
 - [x] Added message to ask user to update Site object when role completes execution
 - [x] Updated tests to run integration tests for notifications

Fixes #214 

--------

Blocked by:
 - [x] https://github.com/openwisp/openwisp-controller/pull/316 -  Refactoring of routes and URLs of openwisp_notifications
 - [x] https://github.com/openwisp/openwisp-notifications/pull/143 - Fixed stalling of migrate command when celery broker is unreachable
 - [x] https://github.com/openwisp/openwisp-notifications/pull/152 - Release openwisp-notifications==0.3.0
 - [x] Release openwisp-controller==0.8
------

I have used this playbook for manually testing this patch on Ubuntu 20.04

```
- hosts: openwisp2
  become: "{{ become | default('yes') }}"
  roles:
    - openwisp.openwisp2
  vars:
    openwisp2_controller_pip: https://github.com/pandafy/openwisp-controller/tarball/fix-notification-settings
    openwisp2_extra_python_packages:
      - django-flat-json-widget
      - https://github.com/openwisp/openwisp-notifications/tarball/master
    openwisp2_default_from_email: "openwisp2@openwisp2.mydomain.com"
```

