### PR TITLE
[feature] Added automatic generation of default SSH credentials #200

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ Now proceed with the following steps:
 3. edit the information of the default organization
 4. in the default organization you just updated, note down the automatically generated *shared secret*
    option, you will need it to use the [auto-registration feature of openwisp-config](https://github.com/openwisp/openwisp-config#automatic-registration)
+4. this Ansible role creates a default template to update ``authorized_keys`` on networking devices
+   using the default access credentials. The role will either use an existing SSH key pair or create
+   a new one if no SSH key pair exists on the host machine.
 
 Now you are ready to start configuring your network! **If you need help** you can ask questions
 on one of the official [OpenWISP Support Channels](http://openwisp.org/support.html).

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Now proceed with the following steps:
 3. edit the information of the default organization
 4. in the default organization you just updated, note down the automatically generated *shared secret*
    option, you will need it to use the [auto-registration feature of openwisp-config](https://github.com/openwisp/openwisp-config#automatic-registration)
-4. this Ansible role creates a default template to update ``authorized_keys`` on networking devices
+5. this Ansible role creates a default template to update ``authorized_keys`` on networking devices
    using the default access credentials. The role will either use an existing SSH key pair or create
    a new one if no SSH key pair exists on the host machine.
 

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -65,6 +65,7 @@
       - libproj-dev
       - libgeos-dev
       - libspatialite-dev
+      - openssh-client
   retries: 5
   delay: 10
   register: result

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -20,6 +20,8 @@
       - python3
       - virtualenv
       - cron
+      # needed to generate SSH key for push updates
+      - openssh-client
   ignore_errors: yes
   retries: 5
   delay: 10
@@ -65,7 +67,6 @@
       - libproj-dev
       - libgeos-dev
       - libspatialite-dev
-      - openssh-client
   retries: 5
   delay: 10
   register: result

--- a/tasks/django.yml
+++ b/tasks/django.yml
@@ -138,8 +138,13 @@
     mode: 0754
 
 - name: load initial data
+  environment:
+    PRIVATE_KEY: "{{ default_private_ssh_key.stdout }}"
+    PUBLIC_KEY: "{{ default_public_ssh_key.stdout }}"
   command: "env/bin/python load_initial_data.py"
   register: load_initial_data_result
-  changed_when: '"created" in load_initial_data_result.stdout'
+  changed_when: >
+    "created" in load_initial_data_result.stdout
+    or "changed" in load_initial_data_result.stdout
   args:
     chdir: "{{ openwisp2_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,9 @@
   tags: [openwisp2, apt]
   when: ansible_os_family == 'Debian'
 
+- import_tasks: ssh.yml
+  tags: [openwisp2, ssh]
+
 - import_tasks: pip.yml
   tags: [openwisp2, pip]
 

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -1,0 +1,19 @@
+- name: Create default SSH key pair
+  become: true
+  user:
+    name: root
+    generate_ssh_key: yes
+    ssh_key_bits: 4096
+    ssh_key_file: .ssh/id_rsa
+
+- name: Get default private SSH key
+  become: true
+  command: cat /root/.ssh/id_rsa
+  register: default_private_ssh_key
+  changed_when: false
+
+- name: Get default public SSH key
+  become: true
+  command: cat /root/.ssh/id_rsa.pub
+  register: default_public_ssh_key
+  changed_when: false

--- a/templates/load_initial_data.py
+++ b/templates/load_initial_data.py
@@ -3,6 +3,8 @@
 - Creates the admin user when openwisp2 is installed
 - Additionally creates the default organization if no organization is present
 - Modifies default Site object
+- Adds a default access credential and updates or creates default
+  template to use the same
 """
 import os
 import django
@@ -11,7 +13,11 @@ django.setup()
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db import IntegrityError
+from swapper import load_model
 
+Credentials = load_model('connection', 'Credentials')
+Template = load_model('config', 'Template')
 User = get_user_model()
 changed = False
 
@@ -29,3 +35,48 @@ if 'django.contrib.sites' in settings.INSTALLED_APPS:
         site.domain = '{{ inventory_hostname }}'
         site.save()
         print('default site updated')
+
+# Get SSH key pair
+ssh_private_key = os.environ.get('PRIVATE_KEY')
+ssh_pub_key = os.environ.get('PUBLIC_KEY')
+
+# Create a default credentials object
+if Credentials.objects.count() == 0:
+    Credentials.objects.create(
+        connector='openwisp_controller.connection.connectors.ssh.Ssh',
+        name='Default',
+        auto_add=True,
+        params={'username': 'root', 'key': ssh_private_key},
+    )
+    print('Credentials object created')
+
+# Update or create default template to add default credentials
+queryset = Template.objects.filter(
+    default=True, config__contains='/etc/dropbear/authorized_keys'
+)
+if queryset.count() == 0:
+    Template.objects.create(
+        name='Default Credentials Template',
+        default=True,
+        backend='netjsonconfig.OpenWrt',
+        config={
+            'files': [
+                {
+                    'path': '/etc/dropbear/authorized_keys',
+                    'mode': '0644',
+                    'contents': ssh_pub_key,
+                },
+            ]
+        },
+    )
+    print('created Default Credentials Template')
+else:
+    for template_obj in queryset.iterator():
+        for config_file in template_obj.config['files']:
+            if (
+                config_file['path'] == '/etc/dropbear/authorized_keys'
+                and ssh_pub_key not in config_file['contents']
+            ):
+                config_file['contents'] += '\n' + ssh_pub_key
+                template_obj.save()
+                print(f'changed {template_obj.name} to add default SSH credential')

--- a/templates/load_initial_data.py
+++ b/templates/load_initial_data.py
@@ -44,7 +44,7 @@ ssh_pub_key = os.environ.get('PUBLIC_KEY')
 if Credentials.objects.count() == 0:
     Credentials.objects.create(
         connector='openwisp_controller.connection.connectors.ssh.Ssh',
-        name='Default',
+        name='OpenWISP Default',
         auto_add=True,
         params={'username': 'root', 'key': ssh_private_key},
     )
@@ -56,7 +56,7 @@ queryset = Template.objects.filter(
 )
 if queryset.count() == 0:
     Template.objects.create(
-        name='Default Credentials Template',
+        name='SSH Keys',
         default=True,
         backend='netjsonconfig.OpenWrt',
         config={


### PR DESCRIPTION
A new SSH keypair will be generated if there does not exist any SSH
key pair on the machine.
The SSH key pair is used to create default access credential which
is used through a default template.
An existing template is updated if it contains configuration to
update the authorized_keys on devices.

Fixes #200