### PR TITLE
[feature] Added support for openwisp-firmware-upgrader #199

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,9 @@ When the playbook is done running, if you got no errors you can login at:
 Enabling the firmware upgrader module
 -------------------------------------
 
+**Note**: It is encouraged that you read the [quick-start guide of openwisp-firmware-upgrader](https://github.com/openwisp/openwisp-firmware-upgrader#quickstart)
+before going ahead.
+
 To enable the firmware upgrader module you need to set `openwisp2_firmware_upgrader` to `true` in
 your `playbook.yml` file. Here's a short summary of how to do this:
 
@@ -461,7 +464,7 @@ When the playbook is done running, if you got no errors you can login at:
     username: admin
     password: admin
 
-**Note**: You can configure `openwisp-firmware-upgrader specific settings <https://github.com/openwisp/openwisp-firmware-upgrader#settings>`_
+**Note**: You can configure [openwisp-firmware-upgrader specific settings](https://github.com/openwisp/openwisp-firmware-upgrader#settings)
 using `openwisp2_extra_django_settings` variable of this ansible role.
 For example if you want to enable the `APIs of openwisp-firmware-upgrader <https://github.com/openwisp/openwisp-firmware-upgrader#rest-api>`_,
 you will update the above playbook as follows:
@@ -473,7 +476,9 @@ you will update the above playbook as follows:
     - openwisp.openwisp2
   vars:
     openwisp2_firmware_upgrader: true
-      OPENWISP_FIRMWARE_UPGRADER_API: True
+    openwisp2_extra_django_settings:
+      OPENWISP_USERS_AUTH_API: true
+      OPENWISP_FIRMWARE_UPGRADER_API: true
 ```
 
 Troubleshooting

--- a/README.md
+++ b/README.md
@@ -429,7 +429,6 @@ When the playbook is done running, if you got no errors you can login at:
     username: admin
     password: admin
 
-
 Enabling the firmware upgrader module
 -------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ When the playbook is done running, if you got no errors you can login at:
 
 **Note**: You can configure [openwisp-firmware-upgrader specific settings](https://github.com/openwisp/openwisp-firmware-upgrader#settings)
 using `openwisp2_extra_django_settings` variable of this ansible role.
-For example if you want to enable the `APIs of openwisp-firmware-upgrader <https://github.com/openwisp/openwisp-firmware-upgrader#rest-api>`_,
+For example if you want to enable the [APIs of openwisp-firmware-upgrader](https://github.com/openwisp/openwisp-firmware-upgrader#rest-api),
 you will update the above playbook as follows:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -429,6 +429,53 @@ When the playbook is done running, if you got no errors you can login at:
     username: admin
     password: admin
 
+
+Enabling the firmware upgrader module
+-------------------------------------
+
+To enable the firmware upgrader module you need to set `openwisp2_firmware_upgrader` to `true` in
+your `playbook.yml` file. Here's a short summary of how to do this:
+
+**Step 1**: [Install ansible](#install-ansible)
+
+**Step 2**: [Install this role](#install-this-role)
+
+**Step 3**: [Create inventory file](#create-inventory-file)
+
+**Step 4**: Create a playbook file with following contents:
+
+```yaml
+- hosts: openwisp2
+  become: "{{ become | default('yes') }}"
+  roles:
+    - openwisp.openwisp2
+  vars:
+    openwisp2_firmware_upgrader: true
+```
+
+**Step 5**: [Run the playbook](#run-the-playbook)
+
+When the playbook is done running, if you got no errors you can login at:
+
+    https://openwisp2.mydomain.com/admin
+    username: admin
+    password: admin
+
+**Note**: You can configure `openwisp-firmware-upgrader specific settings <https://github.com/openwisp/openwisp-firmware-upgrader#settings>`_
+using `openwisp2_extra_django_settings` variable of this ansible role.
+For example if you want to enable the `APIs of openwisp-firmware-upgrader <https://github.com/openwisp/openwisp-firmware-upgrader#rest-api>`_,
+you will update the above playbook as follows:
+
+```yaml
+- hosts: openwisp2
+  become: "{{ become | default('yes') }}"
+  roles:
+    - openwisp.openwisp2
+  vars:
+    openwisp2_firmware_upgrader: true
+      OPENWISP_FIRMWARE_UPGRADER_API: True
+```
+
 Troubleshooting
 ===============
 
@@ -529,6 +576,8 @@ Below are listed all the variables you can customize (you may also want to take 
     # optional openwisp2 modules
     openwisp2_network_topology: false
     openwisp2_network_topology_version: "0.4"
+    openwisp2_firmware_upgrader: false
+    openwisp2_firmware_upgrader_version: "0.1"
     # you may replace the values of these variables with any URL
     # supported by pip (the python package installer)
     # use these to install forks, branches or development versions
@@ -541,6 +590,7 @@ Below are listed all the variables you can customize (you may also want to take 
     openwisp2_django_x509_pip: false
     openwisp2_netjsonconfig_pip: false
     openwisp2_network_topology_pip: false
+    openwisp2_firmware_upgrader_pip: false
     # by default python3 is used, if may need to set this to python2.7 for older systems
     openwisp2_python: python2.7
     # customize the app_path

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,10 @@
 openwisp2_python: python3
 ansible_python_interpreter: /usr/bin/python3
 openwisp2_network_topology: false
-openwisp2_controller_version: "0.8.1"
-openwisp2_network_topology_version: "0.5.1"
+openwisp2_firmware_upgrader: false
+openwisp2_controller_version: "0.7.post1"
+openwisp2_network_topology_version: "0.4"
+openwisp2_firmware_upgrader_version: "0.1"
 openwisp2_controller_pip: false
 openwisp2_users_pip: false
 openwisp2_utils_pip: false
@@ -10,6 +12,7 @@ openwisp2_django_x509_pip: false
 openwisp2_django_loci_pip: false
 openwisp2_netjsonconfig_pip: false
 openwisp2_network_topology_pip: false
+openwisp2_firmware_upgrader_pip: false
 openwisp2_extra_python_packages: [bpython]
 openwisp2_extra_django_apps: []
 openwisp2_extra_django_settings: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,8 @@ openwisp2_python: python3
 ansible_python_interpreter: /usr/bin/python3
 openwisp2_network_topology: false
 openwisp2_firmware_upgrader: false
-openwisp2_controller_version: "0.7.post1"
-openwisp2_network_topology_version: "0.4"
+openwisp2_controller_version: "0.8.1"
+openwisp2_network_topology_version: "0.5.1"
 openwisp2_firmware_upgrader_version: "0.1"
 openwisp2_controller_pip: false
 openwisp2_users_pip: false

--- a/molecule/resources/converge.yml
+++ b/molecule/resources/converge.yml
@@ -6,7 +6,14 @@
 
   vars:
     openwisp2_network_topology: true
+    openwisp2_firmware_upgrader: true
 
+    #TODO: Remove before merging
+    openwisp2_firmware_upgrader_pip : https://github.com/openwisp/openwisp-firmware-upgrader/tarball/refactor-urls
+    openwisp2_controller_pip: https://github.com/openwisp/openwisp-controller/tarball/master
+    openwisp2_extra_python_packages:
+      - https://github.com/openwisp/openwisp-firmware-upgrader/tarball/refactor-urls
+      - https://github.com/openwisp/openwisp-controller/tarball/master
   pre_tasks:
     - name: Update apt cache
       apt: update_cache=true cache_valid_time=600

--- a/molecule/resources/converge.yml
+++ b/molecule/resources/converge.yml
@@ -8,12 +8,6 @@
     openwisp2_network_topology: true
     openwisp2_firmware_upgrader: true
 
-    #TODO: Remove before merging
-    openwisp2_firmware_upgrader_pip : https://github.com/openwisp/openwisp-firmware-upgrader/tarball/refactor-urls
-    openwisp2_controller_pip: https://github.com/openwisp/openwisp-controller/tarball/master
-    openwisp2_extra_python_packages:
-      - https://github.com/openwisp/openwisp-firmware-upgrader/tarball/refactor-urls
-      - https://github.com/openwisp/openwisp-controller/tarball/master
   pre_tasks:
     - name: Update apt cache
       apt: update_cache=true cache_valid_time=600

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -52,6 +52,13 @@
     - "{{ openwisp2_network_topology_pip }}"
   when: item is defined and item is string and openwisp2_network_topology
 
+- name: Add firmware_upgrader to custom package list if set and enabled
+  set_fact:
+    openwisp2_python_packages: "{{ openwisp2_python_packages + [item] }}"
+  with_items:
+    - "{{ openwisp2_firmware_upgrader_pip }}"
+  when: item is defined and item is string and openwisp2_firmware_upgrader
+
 - name: Install cryptography from pip
   pip:
     name: cryptography
@@ -124,6 +131,21 @@
   delay: 10
   register: result
   until: result is success
+
+# TODO: Uncomment when openwisp-firmware-upgrader is released
+# - name: Install openwisp firmware upgrader and its dependencies
+#   when: openwisp2_firmware_upgrader
+#   pip:
+#     name: "openwisp-firmware-upgrader~={{ openwisp2_firmware_upgrader_version }}"
+#     state: latest
+#     virtualenv: "{{ virtualenv_path }}"
+#     virtualenv_python: "{{ openwisp2_python }}"
+#     virtualenv_site_packages: yes
+#   notify: reload supervisor
+#   retries: 5
+#   delay: 10
+#   register: result
+#   until: result is success
 
 - name: Install extra python packages
   pip:

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -132,20 +132,19 @@
   register: result
   until: result is success
 
-# TODO: Uncomment when openwisp-firmware-upgrader is released
-# - name: Install openwisp firmware upgrader and its dependencies
-#   when: openwisp2_firmware_upgrader
-#   pip:
-#     name: "openwisp-firmware-upgrader~={{ openwisp2_firmware_upgrader_version }}"
-#     state: latest
-#     virtualenv: "{{ virtualenv_path }}"
-#     virtualenv_python: "{{ openwisp2_python }}"
-#     virtualenv_site_packages: yes
-#   notify: reload supervisor
-#   retries: 5
-#   delay: 10
-#   register: result
-#   until: result is success
+- name: Install openwisp firmware upgrader and its dependencies
+  when: openwisp2_firmware_upgrader
+  pip:
+    name: "openwisp-firmware-upgrader~={{ openwisp2_firmware_upgrader_version }}"
+    state: latest
+    virtualenv: "{{ virtualenv_path }}"
+    virtualenv_python: "{{ openwisp2_python }}"
+    virtualenv_site_packages: yes
+  notify: reload supervisor
+  retries: 5
+  delay: 10
+  register: result
+  until: result is success
 
 - name: Install extra python packages
   pip:

--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
 {% endif %}
 {% if openwisp2_firmware_upgrader %}
     'openwisp_firmware_upgrader',
+    'private_storage',
 {% endif %}
     # openwisp2 admin theme
     # (must be loaded here)
@@ -79,6 +80,10 @@ EXTENDED_APPS = [
     'django_x509',
     'django_loci',
 ]
+
+{% if openwisp2_firmware_upgrader %}
+PRIVATE_STORAGE_ROOT = '{0}/firmware/'.format(BASE_DIR)
+{% endif %}
 
 AUTH_USER_MODEL = 'openwisp_users.User'
 SITE_ID = 1

--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -50,6 +50,9 @@ INSTALLED_APPS = [
 {% if openwisp2_network_topology %}
     'openwisp_network_topology',
 {% endif %}
+{% if openwisp2_firmware_upgrader %}
+    'openwisp_firmware_upgrader',
+{% endif %}
     # openwisp2 admin theme
     # (must be loaded here)
     'openwisp_utils.admin_theme',

--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -82,7 +82,7 @@ EXTENDED_APPS = [
 ]
 
 {% if openwisp2_firmware_upgrader %}
-PRIVATE_STORAGE_ROOT = '{0}/firmware/'.format(BASE_DIR)
+PRIVATE_STORAGE_ROOT = os.path.join(BASE_DIR, 'private')
 {% endif %}
 
 AUTH_USER_MODEL = 'openwisp_users.User'

--- a/templates/openwisp2/urls.py
+++ b/templates/openwisp2/urls.py
@@ -16,6 +16,9 @@ urlpatterns = [
     {% if openwisp2_network_topology %}
     url(r'^', include('openwisp_network_topology.urls')),
     {% endif %}
+    {% if openwisp2_firmware_upgrader %}
+    url(r'^', include('openwisp_firmware_upgrader.urls')),
+    {% endif %}
     {% for extra_url in openwisp2_extra_urls %}
     {{ extra_url }},
     {% endfor %}


### PR DESCRIPTION
Fixes #199

---------------

#### Playbook used for manual testing on Ubuntu 20.04

```
- hosts: openwisp2
  become: "{{ become | default('yes') }}"
  roles:
    - openwisp.openwisp2
  vars:
    openwisp2_default_from_email: "openwisp2@openwisp2.mydomain.com"

    openwisp2_network_topology: true
    openwisp2_firmware_upgrader: true

    openwisp2_firmware_upgrader_pip : "https://github.com/openwisp/openwisp-firmware-upgrader/tarball/refactor-urls"
    openwisp2_controller_pip: https://github.com/openwisp/openwisp-controller/tarball/master
    openwisp2_extra_python_packages:
      - https://github.com/openwisp/openwisp-firmware-upgrader/tarball/refactor-urls
      - https://github.com/openwisp/openwisp-controller/tarball/master  
```

------------------

**Blockers**
- [ ] https://github.com/openwisp/openwisp-firmware-upgrader/pull/109
- [ ] Release openwisp-firmware-upgrader