### PR TITLE
[fix] Install geographic libraries separately

### DIFF
--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -58,14 +58,22 @@
     line: 'bind 127.0.0.1'
     backrefs: yes
 
+- name: Install geographic libraries
+  apt:
+    name:
+      - gdal-bin
+      - libproj-dev
+      - libgeos-dev
+  retries: 5
+  delay: 10
+  register: result
+  until: result is success
+
 - name: Install spatialite
   when: openwisp2_database.engine == "django.contrib.gis.db.backends.spatialite"
   apt:
     name:
       - sqlite3
-      - gdal-bin
-      - libproj-dev
-      - libgeos-dev
       - libspatialite-dev
   retries: 5
   delay: 10


### PR DESCRIPTION
If the playbook is run the first time with a different DB configured
(eg: Postgis or MySQL), the geographic libraries won't be installed.
Therefore we need to install the geodjango dependencies in a step that
is separate than the installation of spatialite.