### PR TITLE
[change] Pin pip to 20.2.4 to avoid new dependency resolution

### DIFF
--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -1,7 +1,7 @@
 - name: Update pip & related tools
   pip:
     name:
-      - pip
+      - pip==20.2.4
       - setuptools
       - wheel
       - attrs


### PR DESCRIPTION
This is a temporary workaround for #230.

It allows us to play safe and keep using the older dependency resolution algorithm which has been around for a long time.
We can switch to the new one in a few months.