### PR TITLE
[fix] Fixed leaflet marker icon #232

### DIFF
--- a/files/storage.py
+++ b/files/storage.py
@@ -1,0 +1,33 @@
+import fnmatch
+
+from compress_staticfiles.storage import (
+    CompressStaticFilesStorage as BaseCompressStaticFilesStorage,
+)
+from django.conf import settings
+
+
+class FileHashedNameMixin:
+    default_excluded_patterns = ['*.png']
+    excluded_patterns = default_excluded_patterns + getattr(
+        settings, "OPENWISP_STATICFILES_VERSIONED_EXCLUDE", []
+    )
+
+    def hashed_name(self, name, content=None, filename=None):
+        if not any(
+            fnmatch.fnmatch(name, pattern) for pattern in self.excluded_patterns
+        ):
+            return super().hashed_name(name, content, filename)
+        return name
+
+
+class CompressStaticFilesStorage(
+    FileHashedNameMixin, BaseCompressStaticFilesStorage,
+):
+    """
+    A static files storage backend for compression that inherits from
+    django-compress-staticfiles's CompressStaticFilesStorage class;
+    also adds support for excluding file types using
+    "OPENWISP_STATICFILES_VERSIONED_EXCLUDE" setting.
+    """
+
+    pass

--- a/files/storage.py
+++ b/files/storage.py
@@ -7,7 +7,10 @@ from django.conf import settings
 
 
 class FileHashedNameMixin:
-    default_excluded_patterns = ['*.png']
+    default_excluded_patterns = [
+        # Exclude PNGs files of leaflet
+        'leaflet/*/*.png'
+        ]
     excluded_patterns = default_excluded_patterns + getattr(
         settings, "OPENWISP_STATICFILES_VERSIONED_EXCLUDE", []
     )

--- a/tasks/django.yml
+++ b/tasks/django.yml
@@ -93,6 +93,12 @@
 - name: start redis
   service: name=redis state=started
 
+- name: storage.py
+  copy:
+    src: storage.py
+    dest: "{{ openwisp2_path }}/openwisp2/storage.py"
+    mode: 0664
+
 - name: migrate
   notify: reload supervisor
   become: yes

--- a/tasks/django.yml
+++ b/tasks/django.yml
@@ -82,6 +82,12 @@
     group: "{{ www_group }}"
     mode: 0664
 
+- name: storage.py
+  copy:
+    src: storage.py
+    dest: "{{ openwisp2_path }}/openwisp2/storage.py"
+    mode: 0664
+
 - name: routing.py
   notify: reload supervisor
   template:
@@ -92,12 +98,6 @@
 
 - name: start redis
   service: name=redis state=started
-
-- name: storage.py
-  copy:
-    src: storage.py
-    dest: "{{ openwisp2_path }}/openwisp2/storage.py"
-    mode: 0664
 
 - name: migrate
   notify: reload supervisor

--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -332,7 +332,7 @@ LOGGING = {
 # HTML minification with django pipeline
 PIPELINE = { 'PIPELINE_ENABLED': True }
 # static files minification and invalidation with django-compress-staticfiles
-STATICFILES_STORAGE = 'compress_staticfiles.storage.CompressStaticFilesStorage'
+STATICFILES_STORAGE = 'openwisp2.storage.CompressStaticFilesStorage'
 # GZIP compression is handled by nginx
 BROTLI_STATIC_COMPRESSION = False
 GZIP_STATIC_COMPRESSION = False


### PR DESCRIPTION
Bug:
HTTP requests to fetch the marker icon were bogus due to a bug in
leaflet that made it incapable to process versioned static files
created by ManifestFilesMixin.

Fix:
- A custom static storage class with option to exclude files based on
  Unix shell-style wildcards.
- PNG files are excluded from versioning

Fixes #232