### PR TITLE
[fix] Avoid failure in load_initial_data.py if SSH vars not defined

### DIFF
--- a/tasks/django.yml
+++ b/tasks/django.yml
@@ -147,8 +147,8 @@
 
 - name: load initial data
   environment:
-    PRIVATE_KEY: "{{ default_private_ssh_key.stdout }}"
-    PUBLIC_KEY: "{{ default_public_ssh_key.stdout }}"
+    PRIVATE_KEY: "{{ default_private_ssh_key.stdout|default(None) }}"
+    PUBLIC_KEY: "{{ default_public_ssh_key.stdout|default(None) }}"
   command: "env/bin/python load_initial_data.py"
   register: load_initial_data_result
   changed_when: >

--- a/tasks/django.yml
+++ b/tasks/django.yml
@@ -147,8 +147,8 @@
 
 - name: load initial data
   environment:
-    PRIVATE_KEY: "{{ default_private_ssh_key.stdout|default(None) }}"
-    PUBLIC_KEY: "{{ default_public_ssh_key.stdout|default(None) }}"
+    PRIVATE_KEY: "{{ default_private_ssh_key.stdout | default(None) }}"
+    PUBLIC_KEY: "{{ default_public_ssh_key.stdout | default(None) }}"
   command: "env/bin/python load_initial_data.py"
   register: load_initial_data_result
   changed_when: >

--- a/templates/load_initial_data.py
+++ b/templates/load_initial_data.py
@@ -41,7 +41,7 @@ ssh_private_key = os.environ.get('PRIVATE_KEY')
 ssh_pub_key = os.environ.get('PUBLIC_KEY')
 
 # Create a default credentials object
-if Credentials.objects.count() == 0:
+if ssh_private_key and Credentials.objects.count() == 0:
     Credentials.objects.create(
         connector='openwisp_controller.connection.connectors.ssh.Ssh',
         name='OpenWISP Default',
@@ -54,7 +54,7 @@ if Credentials.objects.count() == 0:
 queryset = Template.objects.filter(
     default=True, config__contains='/etc/dropbear/authorized_keys'
 )
-if queryset.count() == 0:
+if ssh_pub_key and queryset.count() == 0:
     Template.objects.create(
         name='SSH Keys',
         default=True,


### PR DESCRIPTION
This can happen when only specific parts of the playbook are run
(eg: by running only specific tags).