### PR TITLE
[fix] Fixed bug affecting installation of custom packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ openwisp2_controller_version: "0.8.2"
 openwisp2_network_topology_version: "0.5.1"
 openwisp2_firmware_upgrader_version: "0.1"
 openwisp2_controller_pip: false
+openwisp2_notifications_pip: false
 openwisp2_users_pip: false
 openwisp2_utils_pip: false
 openwisp2_django_x509_pip: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,6 @@
 
 - import_tasks: apt.yml
   tags: [openwisp2, apt]
-  when: ansible_os_family == 'Debian'
 
 - import_tasks: ssh.yml
   tags: [openwisp2, ssh]

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -45,7 +45,7 @@
     - "{{ openwisp2_django_x509_pip }}"
     - "{{ openwisp2_django_loci_pip }}"
     - "{{ openwisp2_netjsonconfig_pip }}"
-  when: item is defined and item is string
+  when: item is string
 
 - name: Add network_topology to custom package list if set and enabled
   set_fact:


### PR DESCRIPTION
The variable `openwisp2_notifications_pip` was undefined and invalidating the `when` condition, which caused the list to not be set at all.