### PR TITLE
[fix] Revert socialaccount + minor improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,8 +755,6 @@ Below are listed all the variables you can customize (you may also want to take 
     # which will cause log lines to be written to "{{ openwisp2_path }}/log/openwisp2.log"
     # instead of "{{ openwisp2_path }}/log/celery.log" and "{{ openwisp2_path }}/log/celerybeat.log"
     openwisp2_django_celery_logging: false
-    # whether allauth.socialaccount is added to INSTALLED_APPS
-    openwisp2_socialaccount: true
     # postfix is installed by default, set to false if you don't need it
     openwisp2_postfix_install: true
     # allow overriding default `postfix_smtp_sasl_auth_enable` variable

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,6 +104,5 @@ openwisp2_celery_broker_url: redis://{{ openwisp2_redis_host }}:{{ openwisp2_red
 openwisp2_celery_task_acks_late: true
 openwisp2_celery_broker_max_tries: 10
 openwisp2_django_celery_logging: false
-openwisp2_socialaccount: true
 openwisp2_postfix_install: true
 postfix_smtpd_relay_restrictions_override: "permit_sasl_authenticated, permit_mynetworks, check_relay_domains, reject_unauth_destination, reject"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,7 +2,7 @@
 
 - name: reload systemd
   systemd:
-    daemon_reload: yes
+    daemon_reload: true
   when: ansible_distribution_release in ['bionic'] and ansible_service_mgr == 'systemd'
 
 - name: reload supervisor

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -1,7 +1,8 @@
 ---
 
 - name: Update APT package cache
-  apt: update_cache=yes
+  apt:
+    update_cache: true
   changed_when: false
   retries: 5
   delay: 10

--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -37,9 +37,7 @@ INSTALLED_APPS = [
     'openwisp_users.accounts',
     'allauth',
     'allauth.account',
-{% if openwisp2_socialaccount %}
     'allauth.socialaccount',
-{% endif %}
     'django_extensions',
     # openwisp2 modules
     'openwisp_users',


### PR DESCRIPTION
Allauth Social Account app is required by allauth and can't be removed without causing errors when users are deleted.