### PR TITLE
Document openwisp2_django_loci_pip variable in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,10 +591,11 @@ Below are listed all the variables you can customize (you may also want to take 
     # WARNING: only do this if you know what you are doing; disruption
     # of service is very likely to occur during development
     openwisp2_controller_pip: false
+    openwisp2_notifications_pip: false
     openwisp2_users_pip: false
     openwisp2_utils_pip: false
-    openwisp2_notifications_pip: false
     openwisp2_django_x509_pip: false
+    openwisp2_django_loci_pip: false
     openwisp2_netjsonconfig_pip: false
     openwisp2_network_topology_pip: false
     openwisp2_firmware_upgrader_pip: false


### PR DESCRIPTION
I've added `openwisp2_django_loci_pip` to README.md and also moved `openwisp2_notifications_pip` after `openwisp2_controller_pip` to respect the order in which they are defined in `defaults/main.yml` file