### PR TITLE
Remove deprecated django.core.urlresolvers

### DIFF
--- a/templates/openwisp2/urls.py
+++ b/templates/openwisp2/urls.py
@@ -1,12 +1,8 @@
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.urls import reverse_lazy
 from django.views.generic import RedirectView
-
-try:
-    from django.urls import reverse_lazy
-except ImportError:
-    from django.core.urlresolvers import reverse_lazy
 
 redirect_view = RedirectView.as_view(url=reverse_lazy('admin:index'))
 


### PR DESCRIPTION
django.core.urlresolvers was deprecated in Django 1.10 and removed in Django 2.0
openwisp-controller requires at least Django 3.0