### PR TITLE
[fix] correct task and defaults related to `openwisp2_monitoring` changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,6 +96,8 @@ openwisp2_timeseries_database:
     user: "openwisp"
     password: "openwisp"
     name: "openwisp2"
+    host: "localhost"
+    port: 8086
 openwisp2_nginx_access_log: "{{ openwisp2_path }}/log/nginx.access.log"
 openwisp2_nginx_error_log: "{{ openwisp2_path }}/log/nginx.error.log error"
 # keep backward compatibility with old variable openwisp2_eventlet_concurrency

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -135,8 +135,7 @@
 
 - name: Install fping
   when: openwisp2_monitoring is true
-  apt:
-    - fping
+  apt: name=fping
   retries: 5
   delay: 10
   register: result


### PR DESCRIPTION
Hi,

(related to changes introduced in #195 #262)

I was testing out the role so we could add openwisp-monitoring into our ansible deployed controller.
These two files were triggering errors, so I figured I'd push the fixes back.

* `defaults/main.yml` provides defaults for all bar host and port. Given the linked role installs influxdb appropriately without those settings - it seemed sensible to just put the defaults in.

* `tasks/apt.yaml` had old/invalid syntax. I've just updated the task to be the same as previous apt tasks.

This was all we needed to modify to deploy to our pre-existing instance.

Do you folk need any assistance or further work for the other PR? We'd really like to see it make the next release :)

Thanks!