### PR TITLE
[fix] Honour variables for nginx logrotate config

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -46,6 +46,7 @@
   notify: restart nginx
 
 - name: configure nginx log rotation
-  copy:
-    src: logrotate.d/openwisp-nginx
+  template:
+    src: logrotate.d/openwisp-nginx.j2
     dest: /etc/logrotate.d/openwisp-nginx
+    mode: 0644

--- a/templates/logrotate.d/openwisp-nginx.j2
+++ b/templates/logrotate.d/openwisp-nginx.j2
@@ -1,12 +1,12 @@
-/opt/openwisp2/log/nginx*.log {
+{{ openwisp2_path }}/log/nginx*.log {
         maxsize 60M
         missingok
         rotate 5
         compress
         delaycompress
         notifempty
-        create 0640 www-data www-data
-        su root www-data
+        create 0640 {{ www_user }} {{ www_group }}
+        su root {{ www_user }}
         sharedscripts
         postrotate
                 service nginx reload >/dev/null 2>&1


### PR DESCRIPTION
The role allows the `openwisp2_path` variable to be modified, however the nginx logrotate config was a plain file with hardcoded paths and user/group.

This change updates the task to use `template` instead of `copy` and honours the `openwisp2_path`, `www_user` & `www_group` variables defined by the play.

No material changes were observed during testing - logrotate functions as it did before.