### PR TITLE
[chore] Fixed failing build #291

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
         run: |
           pip install molecule[docker,ansible] yamllint ansible-lint docker openwisp-utils[qa]
 
+      - name: Install Ansible Galaxy dependencies
+        run: ansible-galaxy collection install "community.general:>=3.6.0"
+
       - name: QA checks
         run: |
           openwisp-qa-check --skip-isort --skip-flake8 --skip-checkmigrations --skip-black

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ via `ansible-galaxy` (which was installed when installing ansible), therefore ru
 
     ansible-galaxy install openwisp.openwisp2
 
+Ensure that you have correct version of [`community.general`](https://github.com/ansible-collections/community.general)
+collection installed
+
+    ansible-galaxy collection install "community.general:>=3.6.0"
+
 Choose a working directory
 --------------------------
 

--- a/tasks/django.yml
+++ b/tasks/django.yml
@@ -135,6 +135,9 @@
     app_path: "{{ openwisp2_path }}"
     command: "collectstatic --noinput"
     virtualenv: "{{ virtualenv_path }}"
+  register: collectstatic_output
+  changed_when: '"\n0 static files" not in collectstatic_output.out'
+  tags: collectstatic
 
 - name: create load_initial_data.py script
   template:


### PR DESCRIPTION
Due to https://github.com/ansible-collections/community.general/issues/3215,
the CI build was failing and users were also facing problems while
using ansible-openwisp2 role.

The bug in ansible-collections/community.general has been fixed in 3.6.0,
but the idempotence test fails for the collectstatic command when
it is used. This commit also added "changed_when" condition to the 
collectstatic task.

Closes #291