### PR TITLE
[feature] Debian Bullseye/redis 6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - debian10
+          - debian11
 
     steps:
       - uses: actions/checkout@v2

--- a/molecule/local/molecule.yml
+++ b/molecule/local/molecule.yml
@@ -32,6 +32,13 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
+  - name: "openwisp2-debian11"
+    image: "geerlingguy/docker-debian11-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
 provisioner:
   name: ansible
   env:

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -53,14 +53,13 @@
   when: openwisp2_redis_install and use_redis6 is failed
 
 - name: Install redis 4 (fallback)
-  when: openwisp2_redis_install and (use_redis5 is failed or use_redis6 is failed)
+  when: openwisp2_redis_install and (use_redis5 is failed and use_redis6 is failed)
   apt:
     name: "redis-server=5:4*"
   register: use_redis4
   notify:
     - reload systemd
     - start redis
-  ignore_errors: true
 
 # On the newer versions of redis, by default redis
 # binds to localhost on ipv6 address which wouldn't

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -32,6 +32,16 @@
   register: result
   until: result is success
 
+- name: Install redis 6 if available
+  apt:
+    name: "redis-server=5:6*"
+  notify:
+    - reload systemd
+    - start redis
+  ignore_errors: true
+  register: use_redis6
+  when: openwisp2_redis_install
+
 - name: Install redis 5 if available
   apt:
     name: "redis-server=5:5*"
@@ -40,12 +50,13 @@
     - start redis
   ignore_errors: true
   register: use_redis5
-  when: openwisp2_redis_install
+  when: openwisp2_redis_install and use_redis6 is failed
 
 - name: Install redis 4 (fallback)
-  when: openwisp2_redis_install and use_redis5.failed
+  when: openwisp2_redis_install and ( use_redis5 is failed or use_redis6 is failed)
   apt:
     name: "redis-server=5:4*"
+  register: use_redis4
   notify:
     - reload systemd
     - start redis

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -53,7 +53,7 @@
   when: openwisp2_redis_install and use_redis6 is failed
 
 - name: Install redis 4 (fallback)
-  when: openwisp2_redis_install and ( use_redis5 is failed or use_redis6 is failed)
+  when: openwisp2_redis_install and (use_redis5 is failed or use_redis6 is failed)
   apt:
     name: "redis-server=5:4*"
   register: use_redis4

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -80,7 +80,7 @@
     - molecule-idempotence-notest
 
 - name: Pin channels_redis to 2.4 for redis 4 compatibility
-  when: use_redis5 is defined and use_redis5.failed is defined and use_redis5.failed
+  when: use_redis4 is defined and use_redis4 is succeeded
   pip:
     name:
       - channels_redis~=2.4


### PR DESCRIPTION
Debian Bullseye ships with redis 6, so I've added a task that installs redis 6.

Additionally I´ve had to adjust the check in `tasks/pip.yml` to make use of the newly registred variable.

The molecule tests (locally, as well as in github actions), are now also run against debian11 (again using the images by geerlingguy)

Improves on #285 
I wasn't able to reproduce the pip error mentioned in the ticket, so I didn´t change anything on these tasks