### PR TITLE
[change] Added ansible variable to set max file size for upload #269

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,6 +1005,10 @@ Below are listed all the variables you can customize (you may also want to take 
     postfix_smtpd_relay_restrictions_override: permit_mynetworks
     # allows overriding the default duration for keeping notifications
     openwisp2_notifications_delete_old_notifications: 10
+    # Maximum file size(in bytes) allowed to be uploaded as firmware image.
+    # It overrides "openwisp2_nginx_client_max_body_size" setting
+    # and updates nginx configuration accordingly.
+    openwisp2_firmware_upgrader_max_file_size: 41943040 # 40MB
     # to add multi-language support
     openwisp2_internationalization: true
     openwisp2_users_auth_api: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,7 @@ openwisp2_default_cert_validity: 1825
 openwisp2_default_ca_validity: 3650
 openwisp2_default_organization_id: 78f74fdd-67c6-4064-97e1-ce761da30745
 openwisp2_notifications_delete_old_notifications: 90
+openwisp2_firmware_upgrader_max_file_size: 31457280  # 30MB
 openwisp2_topology_update_frequency:
     day: "*"
     hour: "*"

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -1,4 +1,9 @@
 ---
+- name: Set nginx max upload size
+  # Required to allow uploading firmware images
+  set_fact:
+    openwisp2_nginx_client_max_body_size: "{{openwisp2_firmware_upgrader_max_file_size}}"
+  when: openwisp2_firmware_upgrader
 
 - name: create "{{ openwisp2_path }}/public_html"
   file:

--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -99,6 +99,7 @@ EXTENDED_APPS = [
 
 {% if openwisp2_firmware_upgrader or openwisp2_radius %}
 PRIVATE_STORAGE_ROOT = os.path.join(BASE_DIR, 'private')
+OPENWISP_FIRMWARE_UPGRADER_MAX_FILE_SIZE = {{ openwisp2_firmware_upgrader_max_file_size }}
 {% endif %}
 
 AUTH_USER_MODEL = 'openwisp_users.User'


### PR DESCRIPTION
"openwisp2_firmware_upgrader_max_file_size" sets
"OPENWISP_FIRMWARE_UPGRADER_MAX_FILE_SIZE" in settings.py and
 updates "client_max_body_size" in nginx config.

Closes #269