### PR TITLE
[chores] Updated URL routes and updated CompressStaticFilesStorage backend

### DIFF
--- a/files/storage.py
+++ b/files/storage.py
@@ -7,6 +7,21 @@ from django.conf import settings
 
 
 class FileHashedNameMixin:
+    # Workaround for modules that do not completely support Django 4.
+    # TODO: Remove this while adding Django 4.0 support.
+    patterns = (
+        (
+            "*.css",
+            (
+                "(?P<matched>url\\(['\"]{0,1}\\s*(?P<url>.*?)[\"']{0,1}\\))",
+                (
+                    "(?P<matched>@import\\s*[\"']\\s*(?P<url>.*?)[\"'])",
+                    '@import url("%(url)s")',
+                ),
+            ),
+        ),
+    )
+
     default_excluded_patterns = [
         # Exclude PNGs files of leaflet
         'leaflet/*/*.png'

--- a/files/storage.py
+++ b/files/storage.py
@@ -7,8 +7,8 @@ from django.conf import settings
 
 
 class FileHashedNameMixin:
-    # Workaround for modules that do not completely support Django 4.
-    # TODO: Remove this while adding Django 4.0 support.
+    # Workaround for DRF-yasg: https://github.com/axnsan12/drf-yasg/issues/761.
+    # TODO: Remove this when DRF-Yasg introduces proper Django 4.0 support.
     patterns = (
         (
             "*.css",

--- a/templates/openwisp2/urls.py
+++ b/templates/openwisp2/urls.py
@@ -1,34 +1,33 @@
-from django.conf.urls import include, url
+from django.urls import include, path, reverse_lazy
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from django.urls import reverse_lazy
 from django.views.generic import RedirectView
 
 redirect_view = RedirectView.as_view(url=reverse_lazy('admin:index'))
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    path('admin/', admin.site.urls),
 {% if openwisp2_controller_urls %}
-    url(r'', include('openwisp_controller.urls')),
+    path('', include('openwisp_controller.urls')),
 {% endif %}
-    url(r'^api/v1/', include('openwisp_utils.api.urls')),
-    url(r'^api/v1/', include('openwisp_users.api.urls')),
+    path('api/v1/', include('openwisp_utils.api.urls')),
+    path('api/v1/', include('openwisp_users.api.urls')),
 {% if openwisp2_network_topology %}
-    url(r'^', include('openwisp_network_topology.urls')),
+    path('', include('openwisp_network_topology.urls')),
 {% endif %}
 {% if openwisp2_firmware_upgrader %}
-    url(r'^', include('openwisp_firmware_upgrader.urls')),
+    path('', include('openwisp_firmware_upgrader.urls')),
 {% endif %}
 {% if openwisp2_monitoring %}
-    url(r'^', include('openwisp_monitoring.urls')),
+    path('', include('openwisp_monitoring.urls')),
 {% endif %}
 {% if openwisp2_radius and openwisp2_radius_urls %}
-    url(r'^', include('openwisp_radius.urls')),
+    path('', include('openwisp_radius.urls')),
 {% endif %}
 {% for extra_url in openwisp2_extra_urls %}
     {{ extra_url }},
 {% endfor %}
-    url(r'^$', redirect_view, name='index'),
+    path('$', redirect_view, name='index'),
 ]
 
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
- urls.py now uses `path` instead of `url` function
- ManifestFileMixin in Django 4 also process the `sourceMap` comments. Since some dependency packages (e.g. drf-yasg) might not support Django 4 yet, updating of `CompressStaticFilesStorage` is required to get it running with with such packages. 
    - Check Django 4 release note section on [django.contrib.staticfiles](https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#module-django.contrib.staticfiles)
    - Check this issue in drf-yasg: https://github.com/axnsan12/drf-yasg/issues/761
    - I proposed a solution to drf-yasg maintainers here: https://github.com/axnsan12/drf-yasg/commit/d9700dbf8cc80d725a7db485c2d4446c19c29840#r64030387. I will open a PR to fix this issue. 

Followed up from https://github.com/openwisp/ansible-openwisp2/pull/315#pullrequestreview-854795074