### PR TITLE
[change!] Simplify installation of custom modules #193

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,21 +792,22 @@ Below are listed all the variables you can customize (you may also want to take 
   # you can add other roles here
     - openwisp.openwisp2
   vars:
-    # openwisp-controler version
-    openwisp2_controller_version: "0.8.2"
-    # optional openwisp2 modules
-    openwisp2_network_topology: false
-    openwisp2_network_topology_version: "0.5.1"
-    openwisp2_firmware_upgrader: false
-    openwisp2_firmware_upgrader_version: "0.1"
-    openwisp2_monitoring: true
-    openwisp2_monitoring_version: "0.1"
-    openwisp2_radius_version: "0.2.1"
-    openwisp2_django_version: "3.2.0"
     # Enable the modules you want to use
     openwisp2_network_topology: false
     openwisp2_firmware_upgrader: false
-    openwisp2_radius: false
+    openwisp2_monitoring: true
+    # you may replace the values of these variables with any value or URL
+    # supported by pip (the python package installer)
+    # use these to install forks, branches or development versions
+    # WARNING: only do this if you know what you are doing; disruption
+    # of service is very likely to occur if these variables are changed
+    # without careful analysis and testing
+    openwisp2_controller_version: "openwisp-controller~=1.0.0"
+    openwisp2_network_topology_version: "openwisp-network-topology~=1.0.0"
+    openwisp2_firmware_upgrader_version: "openwisp-firmware-upgrader~=1.0.0"
+    openwisp2_monitoring_version: "openwisp-monitoring~=1.0.0"
+    openwisp2_radius_version: "openwisp-radius~=1.0.0"
+    openwisp2_django_version: "django~=3.2.13"
     # Setting this to true will enable subnet division feature of
     # openwisp-controller. Refer openwisp-controller documentation
     # for more information. https://github.com/openwisp/openwisp-controller#subnet-division-app
@@ -817,26 +818,6 @@ Below are listed all the variables you can customize (you may also want to take 
     # views cannot be used, this is helpful if you have an external
     # radius instance.
     openwisp2_radius_urls: "{{ openwisp2_radius }}"
-    # you may replace the values of these variables with any URL
-    # supported by pip (the python package installer)
-    # use these to install forks, branches or development versions
-    # WARNING: only do this if you know what you are doing; disruption
-    # of service is very likely to occur during development
-    # Custom OpenWISP 2 Python packages will be installed with "--no-deps"
-    # parameter, be aware that you will have to add new dependencies if
-    # necessary to "openwisp2_extra_python_packages" var
-    openwisp2_controller_pip: false
-    openwisp2_notifications_pip: false
-    openwisp2_users_pip: false
-    openwisp2_utils_pip: false
-    openwisp2_django_x509_pip: false
-    openwisp2_django_loci_pip: false
-    openwisp2_netjsonconfig_pip: false
-    openwisp2_network_topology_pip: false
-    openwisp2_firmware_upgrader_pip: false
-    openwisp2_monitoring_pip: false
-    openwisp2_radius_pip: false
-    # customize the app_path
     openwisp2_path: /opt/openwisp2
     # It is recommended that you change the value of this variable if you intend to use
     # OpenWISP2 in production, as a misconfiguration may result in emails not being sent

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,27 +8,14 @@ openwisp2_monitoring: true
 openwisp2_radius: false
 openwisp2_controller_subnet_division: false
 openwisp2_radius_urls: "{{ openwisp2_radius }}"
-openwisp2_controller_version: "0.8.2"
-openwisp2_network_topology_version: "0.5.1"
-openwisp2_firmware_upgrader_version: "0.1"
-openwisp2_monitoring_version: "0.1"
-openwisp2_radius_version: "0.2.1"
-openwisp2_django_version: "3.2.0"
-openwisp2_controller_pip: false
-openwisp2_notifications_pip: false
-openwisp2_users_pip: false
-openwisp2_utils_pip: false
-openwisp2_django_x509_pip: false
-openwisp2_django_loci_pip: false
-openwisp2_netjsonconfig_pip: false
-openwisp2_network_topology_pip: false
-openwisp2_firmware_upgrader_pip: false
-openwisp2_monitoring_pip: false
-openwisp2_radius_pip: false
+openwisp2_controller_version: "openwisp-controller~=1.0.0"
+openwisp2_network_topology_version: "openwisp-network-topology~=1.0.0"
+openwisp2_firmware_upgrader_version: "openwisp-firmware-upgrader~=1.0.0"
+openwisp2_monitoring_version: "openwisp-monitoring~=1.0.0"
+openwisp2_radius_version: "openwisp-radius~=1.0.0"
+openwisp2_django_version: "{{ 'django~=4.0.0' if ansible_distribution_release|string in ['focal', 'bullseye'] else 'django~=3.2.13' }}"
 openwisp2_extra_python_packages:
     - bpython
-    # TODO: Remove when openwisp-modules are released
-    - swapper~=1.3.0
 openwisp2_extra_django_apps: []
 openwisp2_extra_django_settings: {}
 openwisp2_extra_django_settings_instructions: []

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -34,56 +34,10 @@
   until: result is success
   notify: reload supervisor
 
-- name: Set openwisp2_python_packages
-  set_fact:
-    openwisp2_python_packages: "{{ openwisp2_python_packages | default([]) }}"
-
-- name: Set custom package list
-  set_fact:
-    openwisp2_python_packages: "{{ openwisp2_python_packages + [item] }}"
-  with_items:
-    - "{{ openwisp2_controller_pip }}"
-    - "{{ openwisp2_notifications_pip }}"
-    - "{{ openwisp2_users_pip }}"
-    - "{{ openwisp2_utils_pip }}"
-    - "{{ openwisp2_django_x509_pip }}"
-    - "{{ openwisp2_django_loci_pip }}"
-    - "{{ openwisp2_netjsonconfig_pip }}"
-  when: item is string
-
-- name: Add network_topology to custom package list if set and enabled
-  set_fact:
-    openwisp2_python_packages: "{{ openwisp2_python_packages + [item] }}"
-  with_items:
-    - "{{ openwisp2_network_topology_pip }}"
-  when: item is defined and item is string and openwisp2_network_topology
-
-- name: Add openwisp_radius to custom package list if set and enabled
-  set_fact:
-    openwisp2_python_packages: "{{ openwisp2_python_packages + [item] }}"
-  with_items:
-    - "{{ openwisp2_radius_pip }}"
-  when: item is defined and item is string and openwisp2_radius
-
-- name: Add firmware_upgrader to custom package list if set and enabled
-  set_fact:
-    openwisp2_python_packages: "{{ openwisp2_python_packages + [item] }}"
-  with_items:
-    - "{{ openwisp2_firmware_upgrader_pip }}"
-  when: item is defined and item is string and openwisp2_firmware_upgrader
-
-- name: Add monitoring to custom package list if set and enabled
-  set_fact:
-    openwisp2_python_packages: "{{ openwisp2_python_packages + [item] }}"
-  with_items:
-    - "{{ openwisp2_monitoring_pip }}"
-  when: item is defined and item is string and openwisp2_monitoring
-
 - name: Install openwisp2 controller and its dependencies
   pip:
     name:
-      # - "openwisp-controller~={{ openwisp2_controller_version }}"
-      - "https://github.com/openwisp/openwisp-controller/tarball/master"
+      - "{{ openwisp2_controller_version }}"
       - service_identity
     state: latest
     virtualenv: "{{ virtualenv_path }}"
@@ -136,8 +90,7 @@
 - name: Install openwisp2 network topology and its dependencies
   when: openwisp2_network_topology
   pip:
-    name: "https://github.com/openwisp/openwisp-network-topology/tarball/master"
-    # name: "openwisp-network-topology~={{ openwisp2_network_topology_version }}"
+    name: "{{ openwisp2_network_topology_version }}"
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
@@ -155,8 +108,7 @@
 - name: Install openwisp firmware upgrader and its dependencies
   when: openwisp2_firmware_upgrader
   pip:
-    name: "https://github.com/openwisp/openwisp-firmware-upgrader/tarball/master"
-    # name: "openwisp-firmware-upgrader~={{ openwisp2_firmware_upgrader_version }}"
+    name: "{{ openwisp2_firmware_upgrader_version }}"
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
@@ -174,8 +126,7 @@
 - name: Install openwisp monitoring and its dependencies
   when: openwisp2_monitoring
   pip:
-    # name: "openwisp-monitoring~={{ openwisp2_monitoring_version }}"
-    name: "https://github.com/openwisp/openwisp-monitoring/tarball/master"
+    name: "{{ openwisp2_monitoring_version }}"
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
@@ -193,8 +144,7 @@
 - name: Install openwisp2_radius and its dependencies
   when: openwisp2_radius
   pip:
-    # name: "openwisp-radius~={{ openwisp2_radius_version }}"
-    name: "https://github.com/openwisp/openwisp-radius/tarball/master"
+    name: "{{ openwisp2_radius_version }}"
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
@@ -229,30 +179,10 @@
   until: result is success
   notify: reload supervisor
 
-- name: Install custom OpenWISP 2 Python packages
-  when: openwisp2_python_packages|length > 0
-  pip:
-    name: "{{ openwisp2_python_packages }}"
-    state: latest
-    virtualenv: "{{ virtualenv_path }}"
-    virtualenv_python: "{{ openwisp2_python }}"
-    virtualenv_site_packages: true
-    extra_args: "--no-deps"
-  environment:
-    SETUPTOOLS_USE_DISTUTILS: stdlib
-  notify: reload supervisor
-  retries: 5
-  delay: 10
-  register: result
-  until: result is success
-  tags:
-    - molecule-idempotence-notest
-
 - name: Install static minification dependencies
   pip:
     name:
       - django-pipeline~=2.0.0
-      - django-compress-staticfiles~=1.0.1b
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
@@ -346,7 +276,7 @@
 
 - name: Install django
   pip:
-    name: "django~={{ openwisp2_django_version }}"
+    name: "{{ openwisp2_django_version }}"
     state: present
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_python }}"
@@ -358,3 +288,5 @@
   register: result
   until: result is success
   notify: reload supervisor
+  tags:
+    - molecule-idempotence-notest


### PR DESCRIPTION
The aim of this backward incompatible change is to simplify the installation of custom modules, which has been very painful to achieve with the current strategy.

The custom module or alternative version can be defined in alternative to the original module, [any custom dependency will have to be defined in the dependency of the module itself using the PEP508 syntax](https://peps.python.org/pep-0508/), however, this is an advanced use case which I do not want to recommend to users, because I don't want novice people mess with the system and then come to cry for help to us when they screw it up, so I didn't add instructions on the usage of PEP508 in the README, I  think we should keep the instructions simple and good enough for general cases, advanced usage like PEP508 is still possible for those who know how to do it.

Closes #193