### PR TITLE
[tests] Fixed coverage warnings in CI build #264

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -6,3 +6,4 @@ skip_list:
   - '306'  # Shells that use pipes should set the pipefail option
   - '403'  # Package installs should not use latest
   - '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern'
+  - 'fqcn-builtins'  # This rule is implicit by default(ansible-lint 6), We need to skip this.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
           MOLECULE_DISTRO: ${{ matrix.distro }}
+          ANSIBLE_ROLES_PATH: /home/runner/.cache/molecule/ansible-openwisp2/default/roles:/home/runner/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
 
   import:
     name: Update imports on Ansible Galaxy

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,5 +3,5 @@
 extends: default
 rules:
   line-length:
-    max: 160
+    max: 162
     level: warning

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,7 +73,7 @@ openwisp2_topology_save_snapshot_frequency:
     day: "*"
     hour: "23"
     minute: "30"
-openwisp2_django_sesame_max_age: 1800 # 30 minutes
+openwisp2_django_sesame_max_age: 1800  # 30 minutes
 openwisp2_nginx_ssl_config:
     gzip: "on"
     gzip_comp_level: "6"
@@ -134,7 +134,7 @@ openwisp2_uwsgi_processes: 1
 openwisp2_uwsgi_threads: 1
 openwisp2_uwsgi_listen: 100
 openwisp2_daphne_processes: 1
-openwisp2_daphne_websocket_timeout: 3600 # in seconds
+openwisp2_daphne_websocket_timeout: 3600  # in seconds
 # internationalization
 openwisp2_internationalization: false
 openwisp2_users_auth_api: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,8 +8,8 @@
 - name: reload supervisor
   command: supervisorctl reload
   notify:
-   - remove celerybeat schedule
-   - migrate timeseries database
+    - remove celerybeat schedule
+    - migrate timeseries database
 
 # Clean up the schedule file because it may become corrupted after updates
 - name: remove celerybeat schedule

--- a/molecule/resources/converge.yml
+++ b/molecule/resources/converge.yml
@@ -23,4 +23,4 @@
         state: absent
 
   roles:
-    - role: ansible-openwisp2
+    - role: openwisp.openwisp2

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -152,10 +152,11 @@
 - name: Should Install Python 3.7
   block:
     - name: Check installed python version
-      shell: "{{ openwisp2_python }} --version"
+      command: "{{ openwisp2_python }} --version"
       register: openwisp2_installed_python
       changed_when: false
-    - set_fact:
+    - name: Check openwisp2 should install python 3.7
+      set_fact:
         openwisp2_should_install_python_37: |
           {{ openwisp2_installed_python.stdout.split(' ')[1] is version_compare('3.7', 'le') }}
 
@@ -185,7 +186,7 @@
       delay: 10
       register: result
       until: result is success
-    - name:
+    - name: Set python 3.7
       set_fact:
         openwisp2_python: python3.7
   when: openwisp2_should_install_python_37 == "True\n"

--- a/tasks/django.yml
+++ b/tasks/django.yml
@@ -179,7 +179,7 @@
   become_user: "{{ www_user }}"
   when: openwisp2_internationalization
   django_manage:
-    app_path: "{{openwisp2_path}}"
+    app_path: "{{ openwisp2_path }}"
     command: "compilemessages"
     virtualenv: "{{ virtualenv_path }}"
 

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -2,7 +2,7 @@
 - name: Set nginx max upload size
   # Required to allow uploading firmware images
   set_fact:
-    openwisp2_nginx_client_max_body_size: "{{openwisp2_firmware_upgrader_max_file_size}}"
+    openwisp2_nginx_client_max_body_size: "{{ openwisp2_firmware_upgrader_max_file_size }}"
   when: openwisp2_firmware_upgrader
 
 - name: create "{{ openwisp2_path }}/public_html"
@@ -91,5 +91,5 @@
     path: /etc/nginx/nginx.conf
     regexp: '#(\s+)server_tokens off'
     replace: 'server_tokens off'
-    backup: yes
+    backup: true
   notify: restart nginx


### PR DESCRIPTION
- Set `ANSIBLE_ROLES_PATH` to where roles actually installed instead of
it's `default path value` that causes **"internal-error the role 'role_name' was not found"**
Current `roles_path value` ensures roles must be installed in `same path` rather than different.
- Fixed `ansible-lint` warnings.
- Added `'fqcn-builtins'` in `.ansible-lint` because this lint rule is implicit
by default in `ansible-lint 6.x` & We need to skip this.

Closes #264