### PR TITLE
[docs] Updated 'How to run tests' section #217

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ To do that, proceed with the following steps:
 
 Clone repository by:
 
-    git clone https://github.com/<your_fork>/ansible-openwisp2.git
+    git clone https://github.com/<your_fork>/ansible-openwisp2.git openwisp.openwisp2
 
 **Step 2**: Install docker
 


### PR DESCRIPTION
 After merging of https://github.com/openwisp/ansible-openwisp2/pull/381, `ansible-openwisp2/molecule/resources/converge.yml` looks like this :
https://github.com/openwisp/ansible-openwisp2/blob/b348970d49785203635562cba75a407f3b154cc2/molecule/resources/converge.yml#L25-L26
- We can now update `How to run tests` section of docs to make sure test suite run properly.
Closes #217