### PR TITLE
[change] Removed sql module from default freeradius site

### DIFF
--- a/templates/freeradius/openwisp_site.j2
+++ b/templates/freeradius/openwisp_site.j2
@@ -20,7 +20,6 @@ server default {
     authorize {
         filter_username
         rest
-        sql
         expiration
         logintime
     }


### PR DESCRIPTION
SQL is not used for authorize and generates some warnings.
Users can still enable this if they need by setting a custom
freeradius site using the variable
"freeradius_openwisp_site_template_src".