### PR TITLE
[fix] Python3 (system) packages should be installed if `false` #393

### DIFF
--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -181,7 +181,7 @@
   delay: 10
   register: result
   until: result is success
-  when: openwisp2_should_install_python_37 == "False\n"
+  when: openwisp2_should_install_python_37 == false
 
 - name: Install ntp
   when: openwisp2_install_ntp


### PR DESCRIPTION
`is_version` returns a boolean.
Checking for string "False\n" resulted in system python3 packages not being installed

Target Host:
```
  Ubuntu: 20.04
  Python: 3.8.10
```

Executing Host (ansible run from):
```
  ansible [core 2.13.2]
  python version = 3.10.6 (main, Aug 11 2022, 13:49:25) [Clang 13.1.6 (clang-1316.0.21.2.5)]
  jinja version = 3.1.2
```

Fixes #393
