### PR TITLE
[chore] Task name, variable and test changes for linting

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ openwisp2_network_topology_version: "openwisp-network-topology~=1.0.0"
 openwisp2_firmware_upgrader_version: "openwisp-firmware-upgrader~=1.0.1"
 openwisp2_monitoring_version: "openwisp-monitoring~=1.0.0"
 openwisp2_radius_version: "openwisp-radius~=1.0.1"
-openwisp2_django_version: "{{ 'django~=4.0.0' if ansible_distribution_release|string in ['focal', 'bullseye'] else 'django~=3.2.13' }}"
+openwisp2_django_version: "{{ 'django~=4.0.0' if ansible_distribution_release | string in ['focal', 'bullseye'] else 'django~=3.2.13' }}"
 openwisp2_extra_python_packages:
     - bpython
 openwisp2_extra_django_apps: []
@@ -147,7 +147,7 @@ openwisp2_radius_delete_old_postauth: 365
 openwisp2_radius_delete_old_radacct: 365
 openwisp2_radius_allowed_hosts: ["127.0.0.1"]
 openwisp2_freeradius_install: true
-freeradius_dir: "{{ '/etc/freeradius/3.0' if ansible_distribution_release|string == 'jammy' else '/etc/freeradius' }}"
+freeradius_dir: "{{ '/etc/freeradius/3.0' if ansible_distribution_release | string == 'jammy' else '/etc/freeradius' }}"
 freeradius_mods_available_dir: "{{ freeradius_dir }}/mods-available"
 freeradius_mods_enabled_dir: "{{ freeradius_dir }}/mods-enabled"
 freeradius_mods_config_dir: "{{ freeradius_dir }}/mods-config"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,25 +1,25 @@
 ---
 
-- name: reload systemd
+- name: Reload systemd
   systemd:
     daemon_reload: true
   when: ansible_distribution_release in ['bionic'] and ansible_service_mgr == 'systemd'
 
-- name: reload supervisor
+- name: Reload supervisor
   command: supervisorctl reload
   notify:
-    - remove celerybeat schedule
-    - migrate timeseries database
+    - Remove celerybeat schedule
+    - Migrate timeseries database
 
 # Clean up the schedule file because it may become corrupted after updates
-- name: remove celerybeat schedule
+- name: Remove celerybeat schedule
   file:
     path: "{{ openwisp2_path }}/celerybeat-schedule.db"
     state: absent
 
 # NOTE: Related to https://github.com/openwisp/openwisp-monitoring/pull/368
 # TODO: Remove this when openwisp-monitoring 1.1.0 is released
-- name: migrate timeseries database
+- name: Migrate timeseries database
   become: true
   become_user: "{{ www_user }}"
   django_manage:
@@ -28,21 +28,21 @@
     virtualenv: "{{ virtualenv_path }}"
   when: openwisp2_monitoring
 
-- name: restart nginx
+- name: Restart nginx
   service:
     name: nginx
     state: restarted
 
-- name: start redis
+- name: Start redis
   when: openwisp2_redis_install
   service:
     name: redis
     state: started
 
-- name: update-ca-certificates
+- name: Update-ca-certificates
   command: /usr/sbin/update-ca-certificates
 
-- name: restart freeradius
+- name: Restart freeradius
   service:
     name: freeradius
     state: started

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,7 +20,7 @@ galaxy_info:
   company: OpenWISP
   description: Official role to install and upgrade openwisp2 controller
   license: BSD
-  min_ansible_version: 2.10
+  min_ansible_version: "2.10"
   issue_tracker_url: https://github.com/openwisp/ansible-openwisp2/issues
   platforms:
     - name: Debian

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -40,16 +40,16 @@
   apt:
     name: redis-server
   notify:
-    - reload systemd
-    - start redis
+    - Reload systemd
+    - Start redis
   when: openwisp2_redis_install
 
 # On the newer versions of redis, by default redis
 # binds to localhost on ipv6 address which wouldn't
 # let the service start if the server doesn't have
 # ipv6 enabled. Hence, we set redis to listen on ipv4
-- name: set redis to listen on ipv4
-  notify: start redis
+- name: Set redis to listen on ipv4
+  notify: Start redis
   when: openwisp2_redis_install
   lineinfile:
     path: /etc/redis/redis.conf
@@ -58,7 +58,7 @@
     backrefs: true
   ignore_errors: true
 
-- name: start redis
+- name: Start redis
   when: openwisp2_redis_install
   service:
     name: redis
@@ -85,7 +85,7 @@
   delay: 10
   register: result
   until: result is success
-  notify: reload systemd
+  notify: Reload systemd
 
 - name: Install postgresql client drivers
   when: openwisp2_database.engine == "django.contrib.gis.db.backends.postgis"
@@ -126,7 +126,7 @@
   until: result is success
   ignore_errors: true
 
-- name: ensure supervisor is started
+- name: Ensure supervisor is started
   service: name=supervisor state=started
 
 - name: Should Install Python 3.7
@@ -169,7 +169,7 @@
     - name: Set python 3.7
       set_fact:
         openwisp2_python: python3.7
-  when: openwisp2_should_install_python_37 == true
+  when: openwisp2_should_install_python_37
 
 - name: Install python3 packages
   apt:
@@ -181,7 +181,7 @@
   delay: 10
   register: result
   until: result is success
-  when: openwisp2_should_install_python_37 == false
+  when: not openwisp2_should_install_python_37
 
 - name: Install ntp
   when: openwisp2_install_ntp

--- a/tasks/django.yml
+++ b/tasks/django.yml
@@ -1,20 +1,20 @@
 ---
 
-- name: create {{ openwisp2_path }}
+- name: Create {{ openwisp2_path }}
   file:
     path: "{{ openwisp2_path }}"
     state: directory
     group: "{{ www_group }}"
     mode: 0770
 
-- name: create "{{ openwisp2_path }}/openwisp2"
+- name: Create "{{ openwisp2_path }}/openwisp2"
   file:
     path: "{{ openwisp2_path }}/openwisp2"
     state: directory
     group: "{{ www_group }}"
     mode: 0770
 
-- name: create "{{ openwisp2_path }}/log"
+- name: Create "{{ openwisp2_path }}/log"
   file:
     path: "{{ openwisp2_path }}/log"
     state: directory
@@ -24,7 +24,7 @@
   tags:
     - molecule-idempotence-notest
 
-- name: create "{{ openwisp2_path }}/static_custom"
+- name: Create "{{ openwisp2_path }}/static_custom"
   file:
     path: "{{ openwisp2_path }}/static_custom"
     state: directory
@@ -33,48 +33,48 @@
   tags:
     - openwisp2_theme
 
-- name: manage.py
-  notify: reload supervisor
+- name: Template manage.py
+  notify: Reload supervisor
   template:
     src: manage.py
     dest: "{{ openwisp2_path }}/manage.py"
     group: "{{ www_group }}"
     mode: 0754
 
-- name: celery.py
-  notify: reload supervisor
+- name: Template celery.py
+  notify: Reload supervisor
   template:
     src: openwisp2/celery.py
     dest: "{{ openwisp2_path }}/openwisp2/celery.py"
     group: "{{ www_group }}"
     mode: 0640
 
-- name: __init__.py
-  notify: reload supervisor
+- name: Template __init__.py
+  notify: Reload supervisor
   template:
     src: openwisp2/__init__.py
     dest: "{{ openwisp2_path }}/openwisp2/__init__.py"
     group: "{{ www_group }}"
     mode: 0640
 
-- name: urls.py
-  notify: reload supervisor
+- name: Template urls.py
+  notify: Reload supervisor
   template:
     src: openwisp2/urls.py
     dest: "{{ openwisp2_path }}/openwisp2/urls.py"
     group: "{{ www_group }}"
     mode: 0640
 
-- name: wsgi.py
-  notify: reload supervisor
+- name: Template wsgi.py
+  notify: Reload supervisor
   template:
     src: openwisp2/wsgi.py
     dest: "{{ openwisp2_path }}/openwisp2/wsgi.py"
     group: "{{ www_group }}"
     mode: 0640
 
-- name: asgi.py
-  notify: reload supervisor
+- name: Template asgi.py
+  notify: Reload supervisor
   template:
     src: openwisp2/asgi.py
     dest: "{{ openwisp2_path }}/openwisp2/asgi.py"
@@ -85,26 +85,26 @@
 - import_tasks: django_secret_key.yml
   when: openwisp2_secret_key is not defined
 
-- name: settings.py
-  notify: reload supervisor
+- name: Template settings.py
+  notify: Reload supervisor
   template:
     src: openwisp2/settings.py
     dest: "{{ openwisp2_path }}/openwisp2/settings.py"
     group: "{{ www_group }}"
     mode: 0640
 
-- name: routing.py
-  notify: reload supervisor
+- name: Template routing.py
+  notify: Reload supervisor
   template:
     src: openwisp2/routing.py
     dest: "{{ openwisp2_path }}/openwisp2/routing.py"
     group: "{{ www_group }}"
     mode: 0640
 
-- name: start redis for migration
+- name: Start redis for migration
   meta: flush_handlers
 
-- name: run geocoding check
+- name: Run geocoding check
   become: true
   become_user: "{{ www_user }}"
   when: openwisp2_geocoding_check
@@ -113,8 +113,8 @@
     command: "check --deploy --tag geocoding"
     virtualenv: "{{ virtualenv_path }}"
 
-- name: migrate
-  notify: reload supervisor
+- name: Migrate
+  notify: Reload supervisor
   become: true
   become_user: "{{ www_user }}"
   django_manage:
@@ -122,7 +122,7 @@
     command: migrate
     virtualenv: "{{ virtualenv_path }}"
 
-- name: set permissions to sqlite db
+- name: Set permissions to sqlite db
   when: openwisp2_database.engine == "django.db.backends.sqlite3"
   file:
     path: "{{ openwisp2_database.name }}"
@@ -130,7 +130,7 @@
     group: "{{ www_group }}"
     mode: 0770
 
-- name: set permissions to "{{ openwisp2_path }}/static"
+- name: Set permissions to "{{ openwisp2_path }}/static"
   file:
     path: "{{ openwisp2_path }}/static"
     state: directory
@@ -142,7 +142,7 @@
   tags:
     - molecule-idempotence-notest
 
-- name: copy static files
+- name: Copy static files
   become: true
   copy:
     src: ow2_static/
@@ -154,8 +154,8 @@
   tags:
     - openwisp2_theme
 
-- name: collectstatic
-  notify: reload supervisor
+- name: Collectstatic
+  notify: Reload supervisor
   become: true
   become_user: "{{ www_user }}"
   django_manage:
@@ -169,7 +169,7 @@
 
 # needed to run compilemessages
 # some .mo files are created in virtualenv_path
-- name: set permissions to "{{ virtualenv_path }}"
+- name: Set permissions to "{{ virtualenv_path }}"
   when: openwisp2_internationalization
   file:
     path: "{{ virtualenv_path }}"
@@ -182,8 +182,8 @@
   tags:
     - molecule-idempotence-notest
 
-- name: compilemessages
-  notify: reload supervisor
+- name: Compilemessages
+  notify: Reload supervisor
   become: true
   become_user: "{{ www_user }}"
   when: openwisp2_internationalization
@@ -192,13 +192,13 @@
     command: "compilemessages"
     virtualenv: "{{ virtualenv_path }}"
 
-- name: create load_initial_data.py script
+- name: Create load_initial_data.py script
   template:
     src: load_initial_data.py
     dest: "{{ openwisp2_path }}/load_initial_data.py"
     mode: 0754
 
-- name: load initial data
+- name: Load initial data
   environment:
     PRIVATE_KEY: "{{ default_private_ssh_key.stdout | default(None) }}"
     PUBLIC_KEY: "{{ default_public_ssh_key.stdout | default(None) }}"

--- a/tasks/django_secret_key.yml
+++ b/tasks/django_secret_key.yml
@@ -1,28 +1,28 @@
 ---
 
-- name: upload generate_django_secret_key.py script
+- name: Upload generate_django_secret_key.py script
   copy:
     src: generate_django_secret_key.py
     dest: "{{ openwisp2_path }}/generate_django_secret_key.py"
     mode: 0754
 
-- name: generate new django SECRET_KEY
+- name: Generate new django SECRET_KEY
   shell: "{{ virtualenv_path }}/bin/python ./generate_django_secret_key.py > .django-secret-key"
   args:
     chdir: "{{ openwisp2_path }}"
     creates: "{{ openwisp2_path }}/.django-secret-key"
 
-- name: get django SECRET_KEY
+- name: Get django SECRET_KEY
   command: "cat .django-secret-key"
   register: secret_key
   changed_when: false
   args:
     chdir: "{{ openwisp2_path }}"
 
-- name: set permission to secret key file
+- name: Set permission to secret key file
   file:
     dest: "{{ openwisp2_path }}/.django-secret-key"
     mode: 0600
 
-- name: set secret_key fact
+- name: Set secret_key fact
   set_fact: openwisp2_secret_key="{{ secret_key.stdout }}"

--- a/tasks/freeradius.yml
+++ b/tasks/freeradius.yml
@@ -88,21 +88,21 @@
     name:
       - freeradius-rest
     state: latest
-  notify: restart freeradius
+  notify: Restart freeradius
 
 - name: Freeradius postgres packages
   when: freeradius_sql.dialect == "postgresql"
   apt:
     name: freeradius-postgresql
     state: latest
-  notify: restart freeradius
+  notify: Restart freeradius
 
 - name: Freeradius mysql packages
   when: freeradius_sql.dialect == "mysql"
   apt:
     name: freeradius-mysql
     state: latest
-  notify: restart freeradius
+  notify: Restart freeradius
 
 - name: SQL configuration
   template:
@@ -111,7 +111,7 @@
     mode: 0640
     owner: freerad
     group: freerad
-  notify: restart freeradius
+  notify: Restart freeradius
 
 - name: Enable SQL module
   file:
@@ -128,9 +128,9 @@
     regexp: "^(.*)safe_characters =(.*)$"
     line: 'safe_characters = "{{ freeradius_safe_characters }}"'
     state: present
-  notify: restart freeradius
+  notify: Restart freeradius
 
-- name: adding user 'freerad' to www-data group for database access
+- name: Adding user 'freerad' to www-data group for database access
   when: freeradius_sql.dialect == "sqlite"
   user:
     name: freerad
@@ -149,7 +149,7 @@
     mode: 0640
     owner: freerad
     group: freerad
-  notify: restart freeradius
+  notify: Restart freeradius
 
 - name: Enable REST module
   file:
@@ -174,7 +174,7 @@
     mode: 0640
     owner: freerad
     group: freerad
-  notify: restart freeradius
+  notify: Restart freeradius
 
 - name: Inner tunnel
   template:
@@ -183,4 +183,4 @@
     mode: 0640
     owner: freerad
     group: freerad
-  notify: restart freeradius
+  notify: Restart freeradius

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -5,25 +5,25 @@
     openwisp2_nginx_client_max_body_size: "{{ openwisp2_firmware_upgrader_max_file_size }}"
   when: openwisp2_firmware_upgrader
 
-- name: create "{{ openwisp2_path }}/public_html"
+- name: Create "{{ openwisp2_path }}/public_html"
   file:
     path: "{{ openwisp2_path }}/public_html"
     state: directory
     mode: 0775
 
-- name: create "{{ openwisp2_path }}/nginx-conf/openwisp2"
+- name: Create "{{ openwisp2_path }}/nginx-conf/openwisp2"
   file:
     path: "{{ openwisp2_path }}/nginx-conf/openwisp2"
     state: directory
     mode: 0770
 
-- name: create "{{ openwisp2_path }}/ssl"
+- name: Create "{{ openwisp2_path }}/ssl"
   file:
     path: "{{ openwisp2_path }}/ssl"
     state: directory
     mode: 0770
 
-- name: create SSL cert if not exists yet
+- name: Create SSL cert if not exists yet
   command: >
     openssl req -new -nodes -x509 \
     -subj "/C={{ openwisp2_ssl_country }}/ST={{ openwisp2_ssl_state }} \
@@ -35,7 +35,7 @@
     -extensions v3_ca creates={{ openwisp2_ssl_cert }}
   args:
     warn: false
-  notify: restart nginx
+  notify: Restart nginx
 
 - name: Copy SSL cert to be added to trusted Cert (for freeradius)
   copy:
@@ -45,51 +45,51 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  notify: update-ca-certificates
+  notify: Update-ca-certificates
 
-- name: disable default nginx configuration
+- name: Disable default nginx configuration
   file:
     path: "/etc/nginx/sites-enabled/default"
     state: absent
 
-- name: nginx SSL configuration
+- name: Nginx SSL configuration
   template:
     src: nginx/ssl-conf.j2
     dest: "{{ openwisp2_path }}/nginx-conf/openwisp2/ssl.conf"
     mode: 0644
-  notify: restart nginx
+  notify: Restart nginx
 
-- name: nginx security configuration
+- name: Nginx security configuration
   template:
     src: nginx/security-conf.j2
     dest: "{{ openwisp2_path }}/nginx-conf/openwisp2/security.conf"
     mode: 0644
-  notify: restart nginx
+  notify: Restart nginx
 
-- name: nginx site available
+- name: Nginx site available
   template:
     src: nginx/site-conf.j2
     dest: "/etc/nginx/sites-available/{{ inventory_hostname }}"
     mode: 0644
-  notify: restart nginx
+  notify: Restart nginx
 
-- name: nginx site enabled
+- name: Nginx site enabled
   file:
     src: "/etc/nginx/sites-available/{{ inventory_hostname }}"
     dest: "/etc/nginx/sites-enabled/{{ inventory_hostname }}"
     state: link
-  notify: restart nginx
+  notify: Restart nginx
 
-- name: configure nginx log rotation
+- name: Configure nginx log rotation
   template:
     src: logrotate.d/openwisp-nginx.j2
     dest: /etc/logrotate.d/openwisp-nginx
     mode: 0644
 
-- name: disable nginx server tokens
+- name: Disable nginx server tokens
   replace:
     path: /etc/nginx/nginx.conf
     regexp: '#(\s+)server_tokens off'
     replace: 'server_tokens off'
     backup: true
-  notify: restart nginx
+  notify: Restart nginx

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -32,7 +32,7 @@
   delay: 5
   register: result
   until: result is success
-  notify: reload supervisor
+  notify: Reload supervisor
 
 - name: Install openwisp2 controller and its dependencies
   pip:
@@ -46,7 +46,7 @@
   environment:
     SETUPTOOLS_USE_DISTUTILS: stdlib
     LC_CTYPE: "en_US.UTF-8"
-  notify: reload supervisor
+  notify: Reload supervisor
   retries: 5
   delay: 10
   register: result
@@ -97,7 +97,7 @@
     virtualenv_site_packages: true
   environment:
     SETUPTOOLS_USE_DISTUTILS: stdlib
-  notify: reload supervisor
+  notify: Reload supervisor
   retries: 5
   delay: 10
   register: result
@@ -113,7 +113,7 @@
     virtualenv_site_packages: true
   environment:
     SETUPTOOLS_USE_DISTUTILS: stdlib
-  notify: reload supervisor
+  notify: Reload supervisor
   retries: 5
   delay: 10
   register: result
@@ -131,7 +131,7 @@
     virtualenv_site_packages: true
   environment:
     SETUPTOOLS_USE_DISTUTILS: stdlib
-  notify: reload supervisor
+  notify: Reload supervisor
   retries: 5
   delay: 10
   register: result
@@ -149,7 +149,7 @@
     virtualenv_site_packages: true
   environment:
     SETUPTOOLS_USE_DISTUTILS: stdlib
-  notify: reload supervisor
+  notify: Reload supervisor
   retries: 5
   delay: 10
   register: result
@@ -167,7 +167,7 @@
     virtualenv_site_packages: true
   environment:
     SETUPTOOLS_USE_DISTUTILS: stdlib
-  notify: reload supervisor
+  notify: Reload supervisor
   retries: 5
   delay: 10
   register: result
@@ -189,7 +189,7 @@
   delay: 10
   register: result
   until: result is success
-  notify: reload supervisor
+  notify: Reload supervisor
 
 - name: Install extra python packages
   pip:
@@ -209,7 +209,7 @@
   delay: 10
   register: result
   until: result is success
-  notify: reload supervisor
+  notify: Reload supervisor
 
 - name: Install static minification dependencies
   pip:
@@ -225,7 +225,7 @@
   delay: 10
   register: result
   until: result is success
-  notify: reload supervisor
+  notify: Reload supervisor
 
 - name: Install uwsgi
   pip:
@@ -240,7 +240,7 @@
   delay: 10
   register: result
   until: result is success
-  notify: reload supervisor
+  notify: Reload supervisor
 
 - name: Install psycopg2
   when: openwisp2_database.engine in ["django.db.backends.postgresql", "django.contrib.gis.db.backends.postgis"]
@@ -256,7 +256,7 @@
   delay: 10
   register: result
   until: result is success
-  notify: reload supervisor
+  notify: Reload supervisor
 
 - name: Install MySQL-python
   when: openwisp2_database.engine in ["django.db.backends.mysql", "django.contrib.gis.db.backends.mysql"]
@@ -272,7 +272,7 @@
   delay: 10
   register: result
   until: result is success
-  notify: reload supervisor
+  notify: Reload supervisor
 
 - name: Install raven (sentry client)
   when: openwisp2_sentry.get('dsn')
@@ -288,7 +288,7 @@
   delay: 10
   register: result
   until: result is success
-  notify: reload supervisor
+  notify: Reload supervisor
 
 - name: Install django-celery-email
   pip:
@@ -304,7 +304,7 @@
   delay: 10
   register: result
   until: result is success
-  notify: reload supervisor
+  notify: Reload supervisor
 
 
 - name: Install django
@@ -320,6 +320,6 @@
   delay: 10
   register: result
   until: result is success
-  notify: reload supervisor
+  notify: Reload supervisor
   tags:
     - molecule-idempotence-notest

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -1,66 +1,66 @@
 ---
 
-- name: uwsgi.ini
+- name: Template for uwsgi.ini
   template:
     src: uwsgi.ini.j2
     dest: "{{ openwisp2_path }}/uwsgi.ini"
     mode: 0644
-  notify: reload supervisor
+  notify: Reload supervisor
 
-- name: supervisor uwsgi
+- name: Template for supervisor uwsgi
   template:
     src: supervisor/openwisp2.j2
     dest: "{{ supervisor_path | format('openwisp2') }}"
     mode: 0644
-  notify: reload supervisor
+  notify: Reload supervisor
 
-- name: supervisor daphne
+- name: Template for supervisor daphne
   template:
     src: supervisor/daphne.j2
     dest: "{{ supervisor_path | format('daphne') }}"
     mode: 0644
-  notify: reload supervisor
+  notify: Reload supervisor
 
-- name: supervisor celery
+- name: Template for supervisor celery
   template:
     src: supervisor/celery.j2
     dest: "{{ supervisor_path | format('celery') }}"
     mode: 0644
-  notify: reload supervisor
+  notify: Reload supervisor
 
-- name: supervisor celery network
+- name: Template for supervisor celery network
   template:
     src: supervisor/celery_network.j2
     dest: "{{ supervisor_path | format('celery_network') }}"
     mode: 0644
   when: openwisp2_celery_network
-  notify: reload supervisor
+  notify: Reload supervisor
 
-- name: supervisor celery firmware_upgrader
+- name: Template for supervisor celery firmware_upgrader
   template:
     src: supervisor/celery_firmware_upgrader.j2
     dest: "{{ supervisor_path | format('celery_firmware_upgrader') }}"
     mode: 0644
   when: openwisp2_firmware_upgrader and openwisp2_celery_firmware_upgrader
-  notify: reload supervisor
+  notify: Reload supervisor
 
-- name: supervisor celery monitoring
+- name: Template for supervisor celery monitoring
   template:
     src: supervisor/celery_monitoring.j2
     dest: "{{ supervisor_path | format('celery_monitoring') }}"
     mode: 0644
   when: openwisp2_monitoring and openwisp2_celery_monitoring
-  notify: reload supervisor
+  notify: Reload supervisor
 
-- name: supervisor celerybeat
+- name: Template for supervisor celerybeat
   template:
     src: supervisor/celerybeat.j2
     dest: "{{ supervisor_path | format('celerybeat') }}"
     mode: 0644
-  notify: reload supervisor
+  notify: Reload supervisor
 
 - name: Remove supervisor runworker.conf (obsolete)
   file:
     dest: "{{ supervisor_path | format('runworker') }}"
     state: absent
-  notify: reload supervisor
+  notify: Reload supervisor


### PR DESCRIPTION
In the interest of reducing the amount of noise generated during role tests, all bar one item that triggered linting errors have been silenced.

The remaining warning is:
```
ignore-errors: Use failed_when and specify error conditions instead of using ignore_errors.
tasks/apt.yml:51 Task/Handler: set redis to listen on ipv4
```
which I left alone because I have no context around how to trigger it / when it would error / why this ignore was introduced.

If you'd prefer this change to happen differently, please let me know.
