### PR TITLE
[feature] Added task add inventory_hostname to /etc/hosts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,10 @@
 - import_tasks: ssh.yml
   tags: [openwisp2, ssh]
 
+- name: Import system tasks
+  import_tasks: system.yml
+  tags: [openwisp2, system]
+
 - import_tasks: pip.yml
   tags: [openwisp2, pip]
 

--- a/tasks/system.yml
+++ b/tasks/system.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Add inventory_hostname in /etc/hosts
+  lineinfile:
+    path: /etc/hosts
+    regexp: "^127.0.0.1"
+    line: "127.0.0.1  localhost {{ inventory_hostname }}"
+    state: present
+  tags:
+    # Docker does not allow updating /etc/hosts file at
+    # container level, hence this task would fail with molecule.
+    # https://github.com/ansible-community/molecule/issues/959
+    - molecule-notest


### PR DESCRIPTION
The /etc/hosts files is updated to resolve inventory_hostname to localhost (127.0.0.1).

**Blockers**
- [x] https://github.com/openwisp/ansible-openwisp2/pull/402