### PR TITLE
[fix] Fixed task for restarting supervisor services

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,8 +10,8 @@ openwisp2_default_supervisor_restart:
   - name: celerybeat
     when: true
   - name: celery_network
-    when: openwisp2_celery_network
+    when: "{{ openwisp2_celery_network }}"
   - name: celery_firmware_upgrader
-    when: openwisp2_firmware_upgrader and openwisp2_celery_firmware_upgrader
+    when: "{{ openwisp2_firmware_upgrader and openwisp2_celery_firmware_upgrader }}"
   - name: celery_monitoring
-    when: openwisp2_monitoring and openwisp2_celery_monitoring
+    when: "{{ openwisp2_monitoring and openwisp2_celery_monitoring }}"


### PR DESCRIPTION
Bug:
The "when" condition defined in "openwisp2_default_supervisor_restart" was not getting evaluated when the task was getting executed.

Fix:
Wrapped the "when" condition in Jinja delimiters ("{{ }}"), so it is evaluated at variable assignment.

Closes https://github.com/openwisp/ansible-openwisp2/issues/406