### PR TITLE
Fix checking for Python version <3.7

### DIFF
--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -138,7 +138,7 @@
     - name: Check openwisp2 should install python 3.7
       set_fact:
         openwisp2_should_install_python_37: |
-          {{ openwisp2_installed_python.stdout.split(' ')[1] is version_compare('3.7', 'le') }}
+          {{ ansible_python_version is version_compare('3.7', 'lt') }}
 
 - name: Install Python 3.7 and required packages from ppa:deadsnakes/ppa
   block:


### PR DESCRIPTION
Running
$ ansible-playbook -i hosts playbook.yml -u user --check would always result in an error because the variable {{openwisp2_installed_python}} would never have been set when running with --check.

It is Ansible best practice to use Ansible native checks wherever possible and it is reasonable to assume that Ansible runs in the Python version the system has. For Python version checking, see https://serverfault.com/a/858684

Another change is to install >= Python 3.7 only if < Python 3.7 is found. The old expression looks as if it would install deadsnakes-python3.7 over system python3.7

Related to issue https://github.com/openwisp/ansible-openwisp2/issues/400