### PR TITLE
[fix] Failure beacuse of `warn` argument

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -33,8 +33,6 @@
     -keyout {{ openwisp2_ssl_key }} \
     -out {{ openwisp2_ssl_cert }} \
     -extensions v3_ca creates={{ openwisp2_ssl_cert }}
-  args:
-    warn: false
   notify: Restart nginx
 
 - name: Copy SSL cert to be added to trusted Cert (for freeradius)


### PR DESCRIPTION
The `warn` argument is causing the failure:
```
TASK [openwisp.openwisp2 : Create SSL cert if not exists yet] **********************************************************************************
fatal: [openwisp]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: _uses_shell, chdir, executable, strip_empty_ends, stdin, argv, creates, _raw_params, stdin_add_newline, removes."}
```

Fixes #414 