### PR TITLE
[docs] Add ansible.posix as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ collection installed
 
     ansible-galaxy collection install "community.general:>=3.6.0"
 
+Ensure that you have `ansible.posix` installed
+
+    ansible-galaxy collection install "ansible.posix"
+
 Choose a working directory
 --------------------------
 

--- a/README.md
+++ b/README.md
@@ -125,13 +125,10 @@ via `ansible-galaxy` (which was installed when installing ansible), therefore ru
 
     ansible-galaxy install openwisp.openwisp2
 
-Ensure that you have correct version of [`community.general`](https://github.com/ansible-collections/community.general)
-collection installed
+Ensure that you have the [`community.general`](https://github.com/ansible-collections/community.general)
+and `ansible.posix` collections installed and up to date:
 
     ansible-galaxy collection install "community.general:>=3.6.0"
-
-Ensure that you have `ansible.posix` installed
-
     ansible-galaxy collection install "ansible.posix"
 
 Choose a working directory


### PR DESCRIPTION
Dependency of openwisp.influxdb/tasks/udp_mode.yml

```
ERROR! couldn't resolve module/action 'ansible.posix.sysctl'. This often indicates a misspelling, missing collection, or incorrect module path.

The error appears to be in '/home/minhnq31/.ansible/roles/openwisp.influxdb/tasks/udp_mode.yml': line 1, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: Set net.core.rmem_max
  ^ here
```