### PR TITLE
[docs] Added molecule-plugins to "How to run tests"

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ To do that, proceed with the following steps:
 Clone repository by:
 
     git clone https://github.com/<your_fork>/ansible-openwisp2.git openwisp.openwisp2
+    cd openwisp.openwisp2
 
 **Step 2**: Install docker
 
@@ -284,7 +285,7 @@ If you haven't installed docker yet, you need to install it (example for linux d
 
 **Step 3**: Install molecule and dependences
 
-    pip install molecule[docker] yamllint ansible-lint docker
+    pip install molecule[docker] molecule-plugins yamllint ansible-lint docker
 
 **Step 4**: Download docker images
 


### PR DESCRIPTION
molecule-plugins should also be installed, otherwise may raise `CRITICAL Failed to find driver docker. Please ensure that the driver is correctly installed.` error, meet this issue when I was trying to execute `molecule test -s local` for test purpose, https://github.com/ansible/molecule/issues/920#issuecomment-1868741469

![image](https://github.com/openwisp/ansible-openwisp2/assets/69415007/e89d5fc1-a029-4577-973b-dd40fe25b770)
