### PR TITLE
[feature] Allow disabling celery beat tasks if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,6 +1232,10 @@ Below are listed all the variables you can customize (you may also want to take 
     # Read https://openwisp-radius.readthedocs.io/en/latest/user/settings.html#openwisp-radius-delete-inactive-users
     openwisp2_radius_delete_inactive_users: 540
     openwisp2_radius_allowed_hosts: ["127.0.0.1"]
+    # allow disabling celery beat tasks if needed
+    openwisp2_monitoring_periodic_tasks: true
+    openwisp2_radius_periodic_tasks: true
+    openwisp2_usage_metric_collection_periodic_tasks: true
     # this role provides a default configuration of freeradius
     # if you manage freeradius on a different machine or you need different configurations
     # you can disable this default behavior

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -213,3 +213,7 @@ openwisp2_django_cors:
     replace_https_referer: false
 openwisp2_extra_supervisor_restart: []
 openwisp2_usage_metric_collection: null
+# allow disabling celery beat tasks if needed
+openwisp2_monitoring_periodic_tasks: true
+openwisp2_radius_periodic_tasks: true
+openwisp2_usage_metric_collection_periodic_tasks: true

--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -260,18 +260,20 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': crontab(**{ {{ cron_password_expiration_email }} }),
     },
 {% endif %}
+{% if openwisp2_notifications_delete_old_notifications %}
     'delete_old_notifications': {
         'task': 'openwisp_notifications.tasks.delete_old_notifications',
         'schedule': crontab(**{ {{ cron_delete_old_notifications }} }),
         'args': ({{ openwisp2_notifications_delete_old_notifications }},),
     },
-{% if openwisp2_monitoring %}
+{% endif %}
+{% if openwisp2_monitoring and openwisp2_monitoring_periodic_tasks %}
     'run_checks': {
         'task': 'openwisp_monitoring.check.tasks.run_checks',
         'schedule': timedelta(minutes=5),
     },
 {% endif %}
-{% if openwisp2_radius %}
+{% if openwisp2_radius and openwisp2_radius_periodic_tasks %}
     'deactivate_expired_users': {
         'task': 'openwisp_radius.tasks.deactivate_expired_users',
         'schedule': crontab(**{ {{ cron_deactivate_expired_users }} }),
@@ -319,7 +321,7 @@ CELERY_BEAT_SCHEDULE = {
         },
     {% endif %}
 {% endif %}
-{% if openwisp2_usage_metric_collection is not false %}
+{% if openwisp2_usage_metric_collection is not false and openwisp2_usage_metric_collection_periodic_tasks %}
     'send_usage_metrics': {
         'task': 'openwisp_utils.measurements.tasks.send_usage_metrics',
         'schedule': timedelta(days=1),


### PR DESCRIPTION
This allows to disable celery beat tasks, useful for multi-VM deployment to avoid duplicated periodic tasks.