### PR TITLE
[fix] Separate version to avoid circular import

### DIFF
--- a/tasks/django.yml
+++ b/tasks/django.yml
@@ -48,6 +48,16 @@
     dest: "{{ openwisp2_path }}/openwisp2/celery.py"
     group: "{{ www_group }}"
     mode: 0640
+  tags: [django_init]
+
+- name: Template version.py
+  notify: Reload application
+  template:
+    src: openwisp2/version.py
+    dest: "{{ openwisp2_path }}/openwisp2/version.py"
+    group: "{{ www_group }}"
+    mode: 0640
+  tags: [django_init]
 
 - name: Template __init__.py
   notify: Reload application

--- a/templates/openwisp2/__init__.py
+++ b/templates/openwisp2/__init__.py
@@ -1,7 +1,8 @@
 from .celery import app as celery_app
+from .version import __openwisp_version__, __openwisp_installation_method__
 
-__all__ = ['celery_app']
-__openwisp_version__ = '24.11.1'
-__openwisp_installation_method__ = (
-    '{{ openwisp2_installation_method | default("ansible-openwisp2") }}'
-)
+__all__ = [
+    'celery_app',
+    '__openwisp_version__',
+    '__openwisp_installation_method__'
+]

--- a/templates/openwisp2/version.py
+++ b/templates/openwisp2/version.py
@@ -1,0 +1,4 @@
+__openwisp_version__ = '24.11.1'
+__openwisp_installation_method__ = (
+    '{{ openwisp2_installation_method | default("ansible-openwisp2") }}'
+)


### PR DESCRIPTION
This patch allows importing the version from settings.py without suffering exceptions which are caused by circular imports.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.