### PR TITLE
[feature] Allow restricting admin access to multiple subnets (openwisp2_admin_allowed_networks)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,6 +64,7 @@ openwisp2_nginx_csp: >
     worker-src https://{{ inventory_hostname }}{% for host in openwisp2_allowed_hosts %} https://{{ host }}{% endfor %} blob: 'self';" always;
 openwisp2_uwsgi_gid: null
 openwisp2_admin_allowed_network: null
+openwisp2_admin_allowed_networks: []
 openwisp2_install_ntp: true
 openwisp2_sentry:
     dsn: false

--- a/docs/user/role-variables.rst
+++ b/docs/user/role-variables.rst
@@ -194,10 +194,11 @@ take a look at `the default values of these variables
         openwisp2_daphne_processes: 2
         # maximum time to allow a websocket to be connected (in seconds)
         openwisp2_daphne_websocket_timeout: 1800
-        # the following setting controls which ip address range
-        # is allowed to access the openwisp2 admin web interface
+        # the following setting controls which ip address ranges
+        # are allowed to access the openwisp2 admin web interface
         # (by default any IP is allowed)
-        openwisp2_admin_allowed_network: null
+        openwisp2_admin_allowed_networks:
+            - "192.168.1.0/24"
         # install ntp client (enabled by default)
         openwisp2_install_ntp: true
         # if you have any custom supervisor service, you can

--- a/templates/nginx/site-conf.j2
+++ b/templates/nginx/site-conf.j2
@@ -65,7 +65,9 @@ server {
     {% if openwisp2_admin_allowed_network %}
     location /admin/ {
         try_files {{ openwisp2_path }}/public_html/maintenance.html $uri @uwsgi;
-        allow {{ openwisp2_admin_allowed_network }};
+        {% for network in openwisp2_admin_allowed_network %}
+        allow {{ network }};
+        {% endfor %}
         deny all;
     }
     {% endif %}

--- a/templates/nginx/site-conf.j2
+++ b/templates/nginx/site-conf.j2
@@ -62,10 +62,13 @@ server {
         proxy_set_header X-Forwarded-Host $server_name;
     }
 
-    {% if openwisp2_admin_allowed_network %}
+    {% if openwisp2_admin_allowed_network or openwisp2_admin_allowed_networks %}
     location /admin/ {
         try_files {{ openwisp2_path }}/public_html/maintenance.html $uri @uwsgi;
-        {% for network in openwisp2_admin_allowed_network %}
+        {% if openwisp2_admin_allowed_network %}
+        allow {{ openwisp2_admin_allowed_network }};
+        {% endif %}
+        {% for network in openwisp2_admin_allowed_networks %}
         allow {{ network }};
         {% endfor %}
         deny all;


### PR DESCRIPTION
Unroll the allowed network list in location admin/, as explicited in nginx docs: https://nginx.org/en/docs/http/ngx_http_access_module.html

Also adds another `openwisp2_admin_allowed_networks` variable to keep `openwisp2_admin_allowed_network` for backward compatibility.

## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [X] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #518, #481.

## Description of Changes

This loop unrolls the value of the variable, to pass nginx config parser
