### PR TITLE
[fix] Update templates/supervisor/daphne.j2 command

### DIFF
--- a/templates/supervisor/daphne.j2
+++ b/templates/supervisor/daphne.j2
@@ -2,7 +2,7 @@
 user={{ www_user }}
 socket=unix://{{ openwisp2_path }}/daphne0.sock
 directory={{ openwisp2_path }}
-command={{ openwisp2_path }}/env/bin/daphne --fd 0 -u {{ openwisp2_path }}/daphne%(process_num)d.sock --access-log - --websocket_timeout {{ openwisp2_daphne_websocket_timeout }} --proxy-headers openwisp2.asgi:application
+command={{ openwisp2_path }}/env/bin/daphne --fd 0 --access-log - --websocket_timeout {{ openwisp2_daphne_websocket_timeout }} --proxy-headers openwisp2.asgi:application
 process_name=asgi%(process_num)d
 numprocs={{ openwisp2_daphne_processes }}
 autostart=true


### PR DESCRIPTION
Daphne should not touch the unix socket managed by supervisor, as supervisor will forward the traffic to `--fd 0`

## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [X] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #520.

## Description of Changes

The unix socket is managed by `supervisor` for this service, and the traffic is forwarded to `fd 0` of the child processes launched.
Therefore `daphne` should not know about the unix socket, or it might disturb `supervisor` handling of it.
Ref: https://supervisord.org/configuration.html#fcgi-program-x-section-settings
