### PR TITLE
Revert "[fix] Prioritize django templates of openwisp extensions over regular apps"

### DIFF
--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -226,8 +226,8 @@ TEMPLATES = [
                     "django.template.loaders.cached.Loader",
                     [
                         "django.template.loaders.filesystem.Loader",
-                        "openwisp_utils.loaders.DependencyLoader",
                         "django.template.loaders.app_directories.Loader",
+                        "openwisp_utils.loaders.DependencyLoader",
                     ],
                 ),
             ],


### PR DESCRIPTION
This reverts commit [78e4759f0900171aceeb45ad16a0b252631b11bc](https://github.com/openwisp/ansible-openwisp2/commit/78e4759f0900171aceeb45ad16a0b252631b11bc).
