### PR TITLE
[change] Dropped debian 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
         distro:
           - ubuntu2204
           - ubuntu2404
-          - debian11
           - debian12
           - debian13
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Ansible role that installs the OpenWISP Server Application.
 
-Tested on **Debian (Trixie/Bookworm/Bullseye)**, **Ubuntu (24/22 LTS)**.
+Tested on **Debian (Trixie/Bookworm)**, **Ubuntu (24/22 LTS)**.
 
 **Recommended minimum ansible core version**: 2.13.
 

--- a/docs/developer/installation.rst
+++ b/docs/developer/installation.rst
@@ -86,7 +86,6 @@ linux debian/ubuntu systems):
     docker pull geerlingguy/docker-ubuntu2204-ansible:latest
     docker pull geerlingguy/docker-debian13-ansible:latest
     docker pull geerlingguy/docker-debian12-ansible:latest
-    docker pull geerlingguy/docker-debian11-ansible:latest
 
 **Step 5**: Run molecule test
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ This ansible role allows deploying the OpenWISP Server Application.
 
 **Recommended minimum ansible core version**: 2.13.
 
-Tested on **Debian (Bookworm/Bullseye)**, **Ubuntu (24/22 LTS)**.
+Tested on **Debian (Trixie/Bookworm)**, **Ubuntu (24/22 LTS)**.
 
 The following diagram illustrates the role of the Ansible OpenWISP role
 within the OpenWISP architecture.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,11 +26,11 @@ galaxy_info:
     - name: Debian
       versions:
         - bookworm
-        - bullseye
+        - trixie
     - name: Ubuntu
       versions:
-        - noble
         - jammy
+        - noble
   galaxy_tags:
     - system
     - networking

--- a/molecule/local/molecule.yml
+++ b/molecule/local/molecule.yml
@@ -27,14 +27,6 @@ platforms:
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
-  - name: "openwisp2-debian11"
-    image: "geerlingguy/docker-debian11-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    pre_build_image: true
   - name: "openwisp2-debian12"
     image: "geerlingguy/docker-debian12-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}


### PR DESCRIPTION
Regular support is already expired, EOL is August 2026, but supporting it for the development version is overkill due to its usage of Python 3.9 which is EOL so we'll remove it.