### PR TITLE
[fix:25.10] Limit django-celery-email-reboot to 4.1.x

### DIFF
--- a/files/requirements-celery-email.txt
+++ b/files/requirements-celery-email.txt
@@ -1,1 +1,1 @@
-django-celery-email-reboot>=4.1.0,<5.0.0
+django-celery-email-reboot<4.2.0


### PR DESCRIPTION
Version 4.2.0 of django-celery-email-reboot removed support for Python 3.9, but in openwisp 25.10 we're still supporting Debian 11, which still uses Python 3.9.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.