### PR TITLE
[deps] Relax django-celery-email-reboot version constraint

### DIFF
--- a/files/requirements-celery-email.txt
+++ b/files/requirements-celery-email.txt
@@ -1,1 +1,1 @@
-django-celery-email-reboot>=4.1.0,<5.0.0
+django-celery-email-reboot>=4.0.0,<5.0.0


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

Allow installation of django-celery-email-reboot~=4.0.1, as versions >=4.1.0 require Python 3.10+, which is not supported in all environments.