### PR TITLE
[chores] Added support for user expiration reminders #608

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -212,8 +212,8 @@ freeradius_eap_openwisp_site_template_src: freeradius/eap/openwisp_site.j2
 freeradius_eap_inner_tunnel_template_src: freeradius/eap/inner_tunnel.j2
 freeradius_eap_template_src: freeradius/eap/eap.j2
 cron_delete_old_notifications: "'hour': 0, 'minute': 0"
-cron_expiration_reminder_email: "'hour': 0, 'minute': 3"
 cron_deactivate_expired_users: "'hour': 0, 'minute': 1"
+cron_expiration_reminder_email: "'hour': 0, 'minute': 3"
 cron_delete_old_radiusbatch_users: "'hour': 0, 'minute': 10"
 cron_cleanup_stale_radacct: "'hour': 0, 'minute': 20"
 cron_delete_old_postauth: "'hour': 0, 'minute': 30"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,9 +17,6 @@ openwisp2_radius_version: "openwisp-radius @ https://github.com/openwisp/openwis
 openwisp2_django_version: "django~=5.2.0"
 openwisp2_extra_python_packages:
   - bpython
-  # TODO: Remove before merging
-  - "openwisp-radius[openvpn_status] @ https://github.com/openwisp/openwisp-radius/tarball/issues/706-user-expiration"
-  - "openwisp-users @ https://github.com/openwisp/openwisp-users/tarball/issues/499-user-expiration"
 openwisp2_extra_django_apps: []
 openwisp2_extra_django_settings: {}
 openwisp2_extra_django_settings_instructions: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,9 @@ openwisp2_radius_version: "openwisp-radius @ https://github.com/openwisp/openwis
 openwisp2_django_version: "django~=5.2.0"
 openwisp2_extra_python_packages:
   - bpython
+  # TODO: Remove before merging
+  - "openwisp-radius[openvpn_status] @ https://github.com/openwisp/openwisp-radius/tarball/issues/706-user-expiration"
+  - "openwisp-users @ https://github.com/openwisp/openwisp-users/tarball/issues/499-user-expiration"
 openwisp2_extra_django_apps: []
 openwisp2_extra_django_settings: {}
 openwisp2_extra_django_settings_instructions: []
@@ -212,7 +215,8 @@ freeradius_eap_openwisp_site_template_src: freeradius/eap/openwisp_site.j2
 freeradius_eap_inner_tunnel_template_src: freeradius/eap/inner_tunnel.j2
 freeradius_eap_template_src: freeradius/eap/eap.j2
 cron_delete_old_notifications: "'hour': 0, 'minute': 0"
-cron_deactivate_expired_users: "'hour': 0, 'minute': 5"
+cron_expiration_reminder_email: "'hour': 0, 'minute': 3"
+cron_deactivate_expired_users: "'hour': 0, 'minute': 1"
 cron_delete_old_radiusbatch_users: "'hour': 0, 'minute': 10"
 cron_cleanup_stale_radacct: "'hour': 0, 'minute': 20"
 cron_delete_old_postauth: "'hour': 0, 'minute': 30"

--- a/docs/user/role-variables.rst
+++ b/docs/user/role-variables.rst
@@ -447,7 +447,8 @@ take a look at `the default values of these variables
         # Defaults to "templates/freeradius/eap/eap.j2" shipped in the role.
         freeradius_eap_template_src: custom_eap.j2
         cron_delete_old_notifications: "'hour': 0, 'minute': 0"
-        cron_deactivate_expired_users: "'hour': 0, 'minute': 5"
+        cron_expiration_reminder_email: "'hour': 0, 'minute': 3"
+        cron_deactivate_expired_users: "'hour': 0, 'minute': 1"
         cron_delete_old_radiusbatch_users: "'hour': 0, 'minute': 10"
         cron_cleanup_stale_radacct: "'hour': 0, 'minute': 20"
         cron_delete_old_postauth: "'hour': 0, 'minute': 30"

--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -256,7 +256,6 @@ CELERY_BEAT_SCHEDULE = {
     "deactivate_expired_users": {
         "task": "openwisp_users.tasks.deactivate_expired_users",
         "schedule": crontab(**{ {{ cron_deactivate_expired_users }} }),
-        "args": None,
     },
     "expiration_reminder_email": {
         "task": "openwisp_users.tasks.expiration_reminder_email",

--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -245,6 +245,7 @@ else:
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     "max_retries": {{ openwisp2_celery_broker_max_tries }},
 }
+
 CELERY_BEAT_SCHEDULE = {
 {% if openwisp2_users_user_password_expiration or openwisp2_users_staff_user_password_expiration %}
     "password_expiry_email": {
@@ -418,6 +419,7 @@ AUTH_PASSWORD_VALIDATORS = [
 LANGUAGE_CODE = "{{ openwisp2_language_code }}"
 TIME_ZONE = "{{ openwisp2_time_zone }}"
 CELERY_TIMEZONE = TIME_ZONE
+
 {% if openwisp2_internationalization %}
 USE_I18N = True
 {% endif %}

--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -245,7 +245,6 @@ else:
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     "max_retries": {{ openwisp2_celery_broker_max_tries }},
 }
-
 CELERY_BEAT_SCHEDULE = {
 {% if openwisp2_users_user_password_expiration or openwisp2_users_staff_user_password_expiration %}
     "password_expiry_email": {
@@ -253,6 +252,15 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(**{ {{ cron_password_expiration_email }} }),
     },
 {% endif %}
+    "deactivate_expired_users": {
+        "task": "openwisp_users.tasks.deactivate_expired_users",
+        "schedule": crontab(**{ {{ cron_deactivate_expired_users }} }),
+        "args": None,
+    },
+    "expiration_reminder_email": {
+        "task": "openwisp_users.tasks.expiration_reminder_email",
+        "schedule": crontab(**{ {{ cron_expiration_reminder_email }} }),
+    },
 {% if openwisp2_notifications_delete_old_notifications %}
     "delete_old_notifications": {
         "task": "openwisp_notifications.tasks.delete_old_notifications",
@@ -267,12 +275,6 @@ CELERY_BEAT_SCHEDULE = {
     },
 {% endif %}
 {% if openwisp2_radius and openwisp2_radius_periodic_tasks %}
-    "deactivate_expired_users": {
-        "task": "openwisp_radius.tasks.deactivate_expired_users",
-        "schedule": crontab(**{ {{ cron_deactivate_expired_users }} }),
-        "args": None,
-        "relative": True,
-    },
     "delete_old_radiusbatch_users": {
         "task": "openwisp_radius.tasks.delete_old_radiusbatch_users",
         "schedule": crontab(**{ {{ cron_delete_old_radiusbatch_users }} }),
@@ -415,6 +417,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "{{ openwisp2_language_code }}"
 TIME_ZONE = "{{ openwisp2_time_zone }}"
+CELERY_TIMEZONE = TIME_ZONE
 {% if openwisp2_internationalization %}
 USE_I18N = True
 {% endif %}


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #608

## Description of Changes

- Added celery beat schedule for expiration reminder emails
- Added support for openwisp_users expiration tasks
- Added configurable reminder email schedule variable

## Blockers 

- [x] https://github.com/openwisp/openwisp-users/pull/517
- [x] https://github.com/openwisp/openwisp-radius/pull/719