### PR TITLE
[feature] Wire persistent-mass-upgrade Beat tasks into ansible-openwisp2 #621

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -97,6 +97,8 @@ openwisp2_celery_firmware_upgrader_concurrency: 1
 openwisp2_celery_firmware_upgrader_autoscale:
 openwisp2_celery_firmware_upgrader_prefetch_multiplier: 1
 openwisp2_celery_firmware_upgrader_optimization: fair
+openwisp2_firmware_upgrader_check_pending_period_minutes: 10
+openwisp2_firmware_upgrader_reminder_scan_period_days: 7
 openwisp2_celery_monitoring: true
 openwisp2_celery_monitoring_concurrency: 2
 openwisp2_celery_monitoring_autoscale:
@@ -234,5 +236,6 @@ openwisp2_usage_metric_collection: true
 openwisp2_monitoring_periodic_tasks: true
 openwisp2_radius_periodic_tasks: true
 openwisp2_usage_metric_collection_periodic_tasks: true
+openwisp2_firmware_upgrader_periodic_tasks: true
 # point {{ inventory_name }} to localhost in /etc/hosts
 openwisp2_inventory_hostname_localhost: true

--- a/docs/user/role-variables.rst
+++ b/docs/user/role-variables.rst
@@ -377,6 +377,9 @@ take a look at `the default values of these variables
         openwisp2_monitoring_periodic_tasks: true
         openwisp2_radius_periodic_tasks: true
         openwisp2_usage_metric_collection_periodic_tasks: true
+        openwisp2_firmware_upgrader_periodic_tasks: true
+        openwisp2_firmware_upgrader_check_pending_period_minutes: 10
+        openwisp2_firmware_upgrader_reminder_scan_period_days: 7
         # point {{ inventory_name }} to localhost in /etc/hosts
         openwisp2_inventory_hostname_localhost: true
         # this role provides a default configuration of freeradius

--- a/molecule/resources/converge.yml
+++ b/molecule/resources/converge.yml
@@ -7,6 +7,7 @@
   vars:
     openwisp2_network_topology: true
     openwisp2_firmware_upgrader: true
+    openwisp2_firmware_upgrader_version: "openwisp-firmware-upgrader @ https://github.com/openwisp/openwisp-firmware-upgrader/tarball/issues/417-persistence-schema-fields"
     openwisp2_radius: true
     openwisp2_controller_subnet_division: true
     openwisp2_uwsgi_extra_conf: |

--- a/templates/openwisp2/settings.py
+++ b/templates/openwisp2/settings.py
@@ -274,6 +274,16 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": timedelta(minutes=5),
     },
 {% endif %}
+{% if openwisp2_firmware_upgrader and openwisp2_firmware_upgrader_periodic_tasks %}
+    "check_pending_upgrades": {
+        "task": "openwisp_firmware_upgrader.tasks.check_pending_upgrades",
+        "schedule": timedelta(minutes={{ openwisp2_firmware_upgrader_check_pending_period_minutes }}),
+    },
+    "send_pending_upgrade_reminders": {
+        "task": "openwisp_firmware_upgrader.tasks.send_pending_upgrade_reminders",
+        "schedule": timedelta(days={{ openwisp2_firmware_upgrader_reminder_scan_period_days }}),
+    },
+{% endif %}
 {% if openwisp2_radius and openwisp2_radius_periodic_tasks %}
     "delete_old_radiusbatch_users": {
         "task": "openwisp_radius.tasks.delete_old_radiusbatch_users",


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #621.

Related to [openwisp/openwisp-firmware-upgrader#379](https://github.com/openwisp/openwisp-firmware-upgrader/issues/379) (parent — Persistent Mass Upgrades) and [openwisp/openwisp-firmware-upgrader#436](https://github.com/openwisp/openwisp-firmware-upgrader/pull/436) (upstream implementation).

## Description of Changes

Once openwisp-firmware-upgrader ships the persistent-mass-upgrades feature, an ansible-deployed install still won't fire its retry loop or its reminder notifications. The `CELERY_BEAT_SCHEDULE = { … }` block in `templates/openwisp2/settings.py` has Jinja gates for users, notifications, monitoring, radius and metrics but no firmware-upgrader entry. Operators would deploy the new release and quietly get none of the new behaviour.

This PR adds the missing entries.

- A Jinja-gated block sits next to `run_checks` (the closest precedent, also a periodic scan). The gate is `openwisp2_firmware_upgrader and openwisp2_firmware_upgrader_periodic_tasks`, mirroring how monitoring/radius/metric_collection wire their Beat entries, so disabling firmware-upgrader at the role level hides the schedule too.
- Three new role variables: `openwisp2_firmware_upgrader_periodic_tasks` (default true), `openwisp2_firmware_upgrader_check_pending_period_minutes` (default 10, the retry-scan period), `openwisp2_firmware_upgrader_reminder_scan_period_days` (default 7, how often the reminder task looks at long-running batches). The per-batch reminder cadence stays controlled upstream by `OPENWISP_FIRMWARE_UPGRADER_PERSISTENT_REMINDER_PERIOD`, default 60 days.
- These are scan workloads, not fixed-clock cron jobs, so `timedelta(...)` is used rather than `crontab(...)` — matches `run_checks`. No `cron_*` string is needed in `vars/main.yml`.
- The variables are documented in `docs/user/role-variables.rst` next to the existing `*_periodic_tasks` rows. The tracking issue suggests `README.md`, but the repo's per-variable reference actually lives in role-variables.rst — `README.md` is 20 lines and has no variable table. Happy to also add a README mention if reviewers prefer.

The second commit (`[chores] TEMPORARY pin firmware-upgrader to gsoc26 branch in molecule converge`) adds an `openwisp2_firmware_upgrader_version` override in `molecule/resources/converge.yml` only, so Molecule installs a version that actually ships the new tasks. `defaults/main.yml` stays untouched. Must be reverted before this branch merges to master.
