### PR TITLE
[chores] Added firmware upgrader websocket routes #534

### DIFF
--- a/templates/openwisp2/routing.py
+++ b/templates/openwisp2/routing.py
@@ -31,6 +31,12 @@ from openwisp_radius.routing import (
 routes.extend(radius_routes)
 {% endif %}
 
+{% if openwisp2_firmware_upgrader %}
+from openwisp_firmware_upgrader.routing import get_routes as get_upgrader_routes
+
+routes.extend(get_upgrader_routes())
+{% endif %}
+
 {% for extra_routes in openwisp2_websocket_extra_routes %}
 routes.extend({{extra_routes}})
 {% endfor %}


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue



Closes #534

## Description of Changes

Added conditional inclusion of websocket routes from openwisp_firmware_upgrader.routing.get_routes() in the Channels routing.py template, gated behind the openwisp2_firmware_upgrader variable.

This is required to support real-time upgrade progress tracking via WebSockets, introduced in openwisp/openwisp-firmware-upgrader#320.